### PR TITLE
spanish-apa.lbx localization.

### DIFF
--- a/tex/latex/biblatex-apa/lbx/spanish-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/spanish-apa.lbx
@@ -30,21 +30,34 @@
 \DeclareBibliographyStrings{%
   inherit          = {spanish},
   inpress          = {{en prensa}{en prensa}},% remove when biblatex has it
+  january          = {{enero}{enero}},
+  february         = {{febrero}{febrero}},
+  march            = {{marzo}{marzo}},
+  april            = {{abril}{abril}},
+  may              = {{mayo}{mayo}},
+  june             = {{junio}{junio}},
+  july             = {{julio}{julio}},
+  august           = {{agosto}{agosto}},
+  september        = {{septiembre}{septiembre}},
+  october          = {{octubre}{octubre}},
+  november         = {{noviembre}{noviembre}},
+  december         = {{diciembre}{diciembre}},
+  nodate           = {{s\adddot f\adddot}{s\adddot f\adddot}},
   mathesis         = {{Tesis\addabbrvspace de\addabbrvspace maestr\'ia}{Tesis\addabbrvspace de\addabbrvspace maestr\'ia}},
   phdthesis        = {{Tesis\addabbrvspace doctoral}{Tesis\addabbrvspace doctoral}},
-  revisededition   = {{Edici\'on\space Revisada}{\'Ed\adddot\space R\'ev\adddot}},
-  producer         = {{producer}{producer}},
-  execproducer     = {{executive producer}{executive producer}},
+  revisededition   = {{Edici\'on\space revisada}{Edici\'on\space revisada}},
+  producer         = {{productor}{productor}},
+  execproducer     = {{productor ejecutivo}{productor ejecutivo}},
   director         = {{director}{director}},
-  writer           = {{writer}{writer}},
-  with             = {{with}{with}},
+  writer           = {{escritor}{escritor}},
+  with             = {{con}{con}},
   page             = {{P\'agina}{{}p\adddot}},
   pages            = {{P\'aginas}{{}pp\adddot}},
   on               = {{el}{el}},
   retrieved        = {{Recuperado}{Recuperado}},
   available        = {{disponible}{disponible}},
   from             = {{desde}{desde}},
-  archivedat       = {{archivado en}{archiv\'es\space \`a}},
+  archivedat       = {{archivado en}{archivado en}},
   reviewof         = {{revisi\'on\space de}{revisi\'on\space de}},
   paragraph        = {{\P}{\P}},
   paragraphs       = {{\P\P}{\P\P}},
@@ -89,31 +102,29 @@
       {\iffieldundef{#1}%
         {}%
         {\addcomma\addspace}%
-       \mkbibmonth{\thefield{#2}}}%
     \iffieldundef{#3}%
       {}%
       {\ifthenelse{\iffieldundef{#2}\OR\iffieldundef{#1}}%
         {}%
-        {\addspace}%
-       \stripzeros{\thefield{#3}}}}%
+        {\stripzeros{\thefield{#3}}\addspace de\addspace}}%
+       \mkbibmonth{\thefield{#2}}%
+}}%
   \protected\def\mkbibdateapalongmdy#1#2#3{%
     \iffieldundef{#3}%
       {}%
-      {\stripzeros{\thefield{#3}}}%
+      {el\addspace\stripzeros{\thefield{#3}}}%
     \iffieldundef{#2}%
-      {}%
+      {\addspace{en}\addspace}%
       {\iffieldundef{#3}%
-        {}%
-        {\addspace}%
-       \mkbibmonth{\thefield{#2}}}%
+        {en\addspace}%
+        {\addspace{de}\addspace}%
+       \mkbibmonth{\thefield{#2}}{\addspace{de}\addspace}}%
     \iffieldundef{#1}%
       {}%
-      {\ifthenelse{\iffieldundef{#2}\OR\iffieldundef{#3}}%
+      {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}}}}
-
-%
+       \thefield{#1}}}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 


### PR DESCRIPTION
Correct long retrieval dates in citations and reference lists, fix some strings such as month names
and other ones previously in French.
It also fixes literal ''nodate'' bibstring appearing in reference lists for works with no date.
