### PR TITLE
Change ngerman-apa.lbx to not go on a lowercasing spree

### DIFF
--- a/tex/latex/biblatex-apa/lbx/austrian-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/austrian-apa.lbx
@@ -63,7 +63,7 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
     \iffieldundef{#3}%
       {}%
       {\iffieldundef{#1}%
@@ -81,7 +81,7 @@
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}\printfield{extrayear}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extrayear}}%
     \iffieldundef{#3}%
       {}%
       {\iffieldundef{#1}%
@@ -111,7 +111,7 @@
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tex/latex/biblatex-apa/lbx/german-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/german-apa.lbx
@@ -63,7 +63,7 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
     \iffieldundef{#3}%
       {}%
       {\iffieldundef{#1}%
@@ -81,7 +81,7 @@
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}\printfield{extrayear}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extrayear}}%
     \iffieldundef{#3}%
       {}%
       {\iffieldundef{#1}%
@@ -111,7 +111,7 @@
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tex/latex/biblatex-apa/lbx/naustrian-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/naustrian-apa.lbx
@@ -63,7 +63,7 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
     \iffieldundef{#3}%
       {}%
       {\iffieldundef{#1}%
@@ -81,7 +81,7 @@
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}\printfield{extrayear}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extrayear}}%
     \iffieldundef{#3}%
       {}%
       {\iffieldundef{#1}%
@@ -111,7 +111,7 @@
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
 
 
 %

--- a/tex/latex/biblatex-apa/lbx/ngerman-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/ngerman-apa.lbx
@@ -63,7 +63,7 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
     \iffieldundef{#3}%
       {}%
       {\iffieldundef{#1}%
@@ -81,7 +81,7 @@
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}\printfield{extrayear}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extrayear}}%
     \iffieldundef{#3}%
       {}%
       {\iffieldundef{#1}%
@@ -111,7 +111,7 @@
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\biblcstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
 
 
 %


### PR DESCRIPTION
The changes should address the primary issue raised in https://github.com/plk/biblatex-apa/issues/10 in that it avoids always lower-casing bibstrings in the date macro.