### PR TITLE
Fix for a spurious space in url+urldate typesetting.

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -1215,7 +1215,7 @@
           \printfield{urldescription}%
           \setunit*{\addcolon\addspace}%
           \iffieldundef{url}{}{\printfield{url}\renewcommand*{\finentrypunct}{\relax}}%
-          \iffieldundef{abstractloc}{}{\printfield{abstractloc}\renewcommand*{\finentrypunct}{\relax}}
+          \iffieldundef{abstractloc}{}{\printfield{abstractloc}\renewcommand*{\finentrypunct}{\relax}}%
           \iffieldundef{abstracturl}{}{\printfield{abstracturl}\renewcommand*{\finentrypunct}{\relax}}}}
 
 %


### PR DESCRIPTION
Appears that url+urldate adds extra space (which can be seen after \fullcite or in \footfullcite). This patch removes it. The bug is present in the currently released biblatex-apa as well.