### PR TITLE
Fix punctuation after ellipsis (#46)

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -409,7 +409,7 @@
 
 \DeclareNameFormat{apaauthor}{%
   \ifthenelse{\value{listcount}=\maxprtauth\AND\value{listcount}<\value{listtotal}}
-    {\addcomma\addspace\ldots\isdot\addspace}
+    {\addcomma\addspace\ldots\isdot}
     {\ifthenelse{\value{listcount}>\maxprtauth\AND\value{listcount}<\value{listtotal}}
       {}
       {\iffieldannotation{uncertain}

--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -409,7 +409,7 @@
 
 \DeclareNameFormat{apaauthor}{%
   \ifthenelse{\value{listcount}=\maxprtauth\AND\value{listcount}<\value{listtotal}}
-    {\addcomma\addspace\ldots\addspace}
+    {\addcomma\addspace\ldots\isdot\addspace}
     {\ifthenelse{\value{listcount}>\maxprtauth\AND\value{listcount}<\value{listtotal}}
       {}
       {\iffieldannotation{uncertain}
@@ -691,7 +691,7 @@
 
 \DeclareNameFormat{apanames}{%
   \ifthenelse{\value{listcount}=\maxprtauth\AND\value{listcount}<\value{listtotal}}
-    {\addcomma\addspace\ldots}
+    {\addcomma\addspace\ldots\isdot}
     {\ifthenelse{\value{listcount}>\maxprtauth\AND\value{listcount}<\value{listtotal}}
       {}
       {\usebibmacro{name:apa:given-family}%


### PR DESCRIPTION
See #46. This makes sure that the ellipsis for name omission is treated like a dot for punctuation purposes. In particular it can now be followed by a comma (it will not be swallowed).