### PR TITLE
Fix German date format

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -100,66 +100,70 @@
 
 % Date formats. Suppress end range of less specific fields
 \newcommand*{\mkdaterangeapalong}[1]{%
-  \blx@metadateinfo{#1}%
-  \iffieldundef{#1year}{}
-    {\datecircaprint
-     \ifstrequal{#1}{url}% URL dates are unlikely to be BCE ...
-       {\printtext{%
-           \mkbibdateapalongmdy{#1year}{#1month}{#1day}%
-           \iffieldundef{#1endyear}%
-             {}%
-             {\iffieldequalstr{#1endyear}{}% open-ended range?
-               {\mbox{\bibdatedash}}
-               {\bibdatedash%
-                \iffieldsequal{#1year}{#1endyear}%
-                  {\iffieldsequal{#1month}{#1endmonth}%
-                    {\iffieldsequal{#1day}{#1endday}%
-                      {}%
-                      {\mkbibdateapalongmdy{}{}{#1endday}}}%
-                    {\mkbibdateapalongmdy{}{#1endmonth}{#1endday}}}%
-                  {\mkbibdateapalongmdy{#1endyear}{#1endmonth}{#1endday}}}}%
-           \dateuncertainprint}}
-       {\printtext{%
-           \mkbibdateapalong{#1year}{#1month}{#1day}%
-           \dateeraprint{#1year}%
-           \iffieldundef{#1endyear}%
-             {}%
-             {\iffieldequalstr{#1endyear}{}% open-ended range?
-               {\mbox{\bibdatedash}}
-               {\bibdatedash%
-                \iffieldsequal{#1year}{#1endyear}%
-                  {\iffieldsequal{#1month}{#1endmonth}%
-                    {\iffieldsequal{#1day}{#1endday}%
-                      {}%
-                      {\mkbibdateapalong{}{}{#1endday}}}%
-                    {\mkbibdateapalong{}{#1endmonth}{#1endday}}}%
-                  {\mkbibdateapalong{#1endyear}{#1endmonth}{#1endday}%
-                 \dateeraprint{#1endyear}}}%
-             \enddateuncertainprint}}}}}
+  \begingroup
+    \blx@metadateinfo{#1}%
+    \iffieldundef{#1year}{}
+      {\datecircaprint
+       \ifstrequal{#1}{url}% URL dates are unlikely to be BCE ...
+         {\printtext{%
+             \mkbibdateapalongmdy{#1year}{#1month}{#1day}%
+             \iffieldundef{#1endyear}%
+               {}%
+               {\iffieldequalstr{#1endyear}{}% open-ended range?
+                 {\mbox{\bibdatedash}}
+                 {\bibdatedash%
+                  \iffieldsequal{#1year}{#1endyear}%
+                    {\iffieldsequal{#1month}{#1endmonth}%
+                      {\iffieldsequal{#1day}{#1endday}%
+                        {}%
+                        {\mkbibdateapalongmdy{}{}{#1endday}}}%
+                      {\mkbibdateapalongmdy{}{#1endmonth}{#1endday}}}%
+                    {\mkbibdateapalongmdy{#1endyear}{#1endmonth}{#1endday}}}}%
+             \dateuncertainprint}}
+         {\printtext{%
+             \mkbibdateapalong{#1year}{#1month}{#1day}%
+             \dateeraprint{#1year}%
+             \iffieldundef{#1endyear}%
+               {}%
+               {\iffieldequalstr{#1endyear}{}% open-ended range?
+                 {\mbox{\bibdatedash}}
+                 {\bibdatedash%
+                  \iffieldsequal{#1year}{#1endyear}%
+                    {\iffieldsequal{#1month}{#1endmonth}%
+                      {\iffieldsequal{#1day}{#1endday}%
+                        {}%
+                        {\mkbibdateapalong{}{}{#1endday}}}%
+                      {\mkbibdateapalong{}{#1endmonth}{#1endday}}}%
+                    {\mkbibdateapalong{#1endyear}{#1endmonth}{#1endday}%
+                   \dateeraprint{#1endyear}}}%
+               \enddateuncertainprint}}}}%
+  \endgroup}
 
 % Only for DATE as only \printdateextra is used
 \newcommand*{\mkdaterangeapalongextra}[1]{%
-  \blx@metadateinfo{#1}%
-  \iffieldundef{#1year}{}
-    {\printtext{%
-      \datecircaprint
-      \mkbibdateapalongextra{#1year}{#1month}{#1day}%
-      \dateeraprint{#1year}%
-      \dateuncertainprint
-      \iffieldundef{#1endyear}%
-        {}%
-        {\iffieldequalstr{#1endyear}{}% open-ended range?
-          {\mbox{\bibdatedash}}
-          {\bibdatedash%
-           \iffieldsequal{#1year}{#1endyear}%
-             {\iffieldsequal{#1month}{#1endmonth}%
-                {\iffieldsequal{#1day}{#1endday}%
-                  {}%
-                  {\mkbibdateapalongextra{}{}{#1endday}}}
-                {\mkbibdateapalongextra{}{#1endmonth}{#1endday}}}
-             {\mkbibdateapalongextra{#1endyear}{#1endmonth}{#1endday}%
-              \dateeraprint{#1endyear}}}%
-         \enddateuncertainprint}}}}
+  \begingroup
+    \blx@metadateinfo{#1}%
+    \iffieldundef{#1year}{}
+      {\printtext{%
+        \datecircaprint
+        \mkbibdateapalongextra{#1year}{#1month}{#1day}%
+        \dateeraprint{#1year}%
+        \dateuncertainprint
+        \iffieldundef{#1endyear}%
+          {}%
+          {\iffieldequalstr{#1endyear}{}% open-ended range?
+            {\mbox{\bibdatedash}}
+            {\bibdatedash%
+             \iffieldsequal{#1year}{#1endyear}%
+               {\iffieldsequal{#1month}{#1endmonth}%
+                  {\iffieldsequal{#1day}{#1endday}%
+                    {}%
+                    {\mkbibdateapalongextra{}{}{#1endday}}}
+                  {\mkbibdateapalongextra{}{#1endmonth}{#1endday}}}
+               {\mkbibdateapalongextra{#1endyear}{#1endmonth}{#1endday}%
+                \dateeraprint{#1endyear}}}%
+           \enddateuncertainprint}}}%
+  \endgroup}
 
 \AtEndPreamble{%
   \renewcommand*{\datecircaprint}{%

--- a/tex/latex/biblatex-apa/lbx/austrian-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/austrian-apa.lbx
@@ -71,55 +71,123 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extradate}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \printfield{extradate}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongmdy#1#2#3{%
     \iffieldundef{#3}%
       {}%
-      {\stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}}%
     \iffieldundef{#2}%
       {}%
       {\iffieldundef{#3}%
         {}%
-        {\adddot\addspace}%
+        {\addspace}%
        \mkbibmonth{\thefield{#2}}}%
     \iffieldundef{#1}%
       {}%
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}%
+  \def\apa@lbx@de@mkdaterangeapalong#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\datecircaprint
+         \ifstrequal{#1}{url}% URL dates are unlikely to be BCE ...
+           {\printtext{%
+               \iffieldsequal{#1year}{#1endyear}
+                 {\iffieldsequal{#1month}{#1endmonth}
+                    {\mkbibdateapalongmdy{}{}{#1day}}
+                    {\mkbibdateapalongmdy{}{#1month}{#1day}}}
+                 {\mkbibdateapalongmdy{#1year}{#1month}{#1day}}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \mkbibdateapalongmdy{#1endyear}{#1endmonth}{#1endday}}}%
+               \dateuncertainprint}}
+           {\printtext{%
+               \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+                 {\mkbibdateapalong{#1year}{}{#1day}}%
+                 {\mkbibdateapalong{#1year}{#1month}{#1day}}%
+               \dateeraprint{#1year}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \iffieldsequal{#1year}{#1endyear}%
+                      {\mkbibdateapalong{}{#1endmonth}{#1endday}}%
+                      {\mkbibdateapalong{#1endyear}{#1endmonth}{#1endday}%
+                     \dateeraprint{#1endyear}}}%
+                 \enddateuncertainprint}}}}%
+    \endgroup}%
+  \def\apa@lbx@de@mkdaterangeapalongextra#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\printtext{%
+          \datecircaprint
+          \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+            {\mkbibdateapalongextra{#1year}{}{#1day}}%
+            {\mkbibdateapalongextra{#1year}{#1month}{#1day}}%
+          \dateeraprint{#1year}%
+          \dateuncertainprint
+          \iffieldundef{#1endyear}%
+            {}%
+            {\iffieldequalstr{#1endyear}{}% open-ended range?
+              {\mbox{\bibdatedash}}
+              {\bibdatedash%
+               \iffieldsequal{#1year}{#1endyear}%
+                 {\mkbibdateapalongextra{}{#1endmonth}{#1endday}}
+                 {\mkbibdateapalongextra{#1endyear}{#1endmonth}{#1endday}%
+                  \dateeraprint{#1endyear}}}%
+             \enddateuncertainprint}}}%
+    \endgroup}%
+  \savecommand\mkdaterangeapalong
+  \savecommand\mkdaterangeapalongextra
+  \def\mkdaterangeapalong{%
+    \apa@lbx@de@mkdaterangeapalong}%
+  \def\mkdaterangeapalongextra#1{%
+    \apa@lbx@de@mkdaterangeapalongextra{#1}}%
+}
+
+\UndeclareBibliographyExtras{%
+  \restorecommand\mkdaterangeapalong
+  \restorecommand\mkdaterangeapalongextra
+}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tex/latex/biblatex-apa/lbx/german-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/german-apa.lbx
@@ -71,56 +71,123 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extradate}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \printfield{extradate}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongmdy#1#2#3{%
     \iffieldundef{#3}%
       {}%
-      {\stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}}%
     \iffieldundef{#2}%
       {}%
       {\iffieldundef{#3}%
         {}%
-        {\adddot\addspace}%
+        {\addspace}%
        \mkbibmonth{\thefield{#2}}}%
     \iffieldundef{#1}%
       {}%
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}%
+  \def\apa@lbx@de@mkdaterangeapalong#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\datecircaprint
+         \ifstrequal{#1}{url}% URL dates are unlikely to be BCE ...
+           {\printtext{%
+               \iffieldsequal{#1year}{#1endyear}
+                 {\iffieldsequal{#1month}{#1endmonth}
+                    {\mkbibdateapalongmdy{}{}{#1day}}
+                    {\mkbibdateapalongmdy{}{#1month}{#1day}}}
+                 {\mkbibdateapalongmdy{#1year}{#1month}{#1day}}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \mkbibdateapalongmdy{#1endyear}{#1endmonth}{#1endday}}}%
+               \dateuncertainprint}}
+           {\printtext{%
+               \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+                 {\mkbibdateapalong{#1year}{}{#1day}}%
+                 {\mkbibdateapalong{#1year}{#1month}{#1day}}%
+               \dateeraprint{#1year}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \iffieldsequal{#1year}{#1endyear}%
+                      {\mkbibdateapalong{}{#1endmonth}{#1endday}}%
+                      {\mkbibdateapalong{#1endyear}{#1endmonth}{#1endday}%
+                     \dateeraprint{#1endyear}}}%
+                 \enddateuncertainprint}}}}%
+    \endgroup}%
+  \def\apa@lbx@de@mkdaterangeapalongextra#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\printtext{%
+          \datecircaprint
+          \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+            {\mkbibdateapalongextra{#1year}{}{#1day}}%
+            {\mkbibdateapalongextra{#1year}{#1month}{#1day}}%
+          \dateeraprint{#1year}%
+          \dateuncertainprint
+          \iffieldundef{#1endyear}%
+            {}%
+            {\iffieldequalstr{#1endyear}{}% open-ended range?
+              {\mbox{\bibdatedash}}
+              {\bibdatedash%
+               \iffieldsequal{#1year}{#1endyear}%
+                 {\mkbibdateapalongextra{}{#1endmonth}{#1endday}}
+                 {\mkbibdateapalongextra{#1endyear}{#1endmonth}{#1endday}%
+                  \dateeraprint{#1endyear}}}%
+             \enddateuncertainprint}}}%
+    \endgroup}%
+  \savecommand\mkdaterangeapalong
+  \savecommand\mkdaterangeapalongextra
+  \def\mkdaterangeapalong{%
+    \apa@lbx@de@mkdaterangeapalong}%
+  \def\mkdaterangeapalongextra#1{%
+    \apa@lbx@de@mkdaterangeapalongextra{#1}}%
+}
 
+\UndeclareBibliographyExtras{%
+  \restorecommand\mkdaterangeapalong
+  \restorecommand\mkdaterangeapalongextra
+}
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/tex/latex/biblatex-apa/lbx/naustrian-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/naustrian-apa.lbx
@@ -71,55 +71,123 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extradate}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \printfield{extradate}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongmdy#1#2#3{%
     \iffieldundef{#3}%
       {}%
-      {\stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}}%
     \iffieldundef{#2}%
       {}%
       {\iffieldundef{#3}%
         {}%
-        {\adddot\addspace}%
+        {\addspace}%
        \mkbibmonth{\thefield{#2}}}%
     \iffieldundef{#1}%
       {}%
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}%
+  \def\apa@lbx@de@mkdaterangeapalong#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\datecircaprint
+         \ifstrequal{#1}{url}% URL dates are unlikely to be BCE ...
+           {\printtext{%
+               \iffieldsequal{#1year}{#1endyear}
+                 {\iffieldsequal{#1month}{#1endmonth}
+                    {\mkbibdateapalongmdy{}{}{#1day}}
+                    {\mkbibdateapalongmdy{}{#1month}{#1day}}}
+                 {\mkbibdateapalongmdy{#1year}{#1month}{#1day}}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \mkbibdateapalongmdy{#1endyear}{#1endmonth}{#1endday}}}%
+               \dateuncertainprint}}
+           {\printtext{%
+               \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+                 {\mkbibdateapalong{#1year}{}{#1day}}%
+                 {\mkbibdateapalong{#1year}{#1month}{#1day}}%
+               \dateeraprint{#1year}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \iffieldsequal{#1year}{#1endyear}%
+                      {\mkbibdateapalong{}{#1endmonth}{#1endday}}%
+                      {\mkbibdateapalong{#1endyear}{#1endmonth}{#1endday}%
+                     \dateeraprint{#1endyear}}}%
+                 \enddateuncertainprint}}}}%
+    \endgroup}%
+  \def\apa@lbx@de@mkdaterangeapalongextra#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\printtext{%
+          \datecircaprint
+          \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+            {\mkbibdateapalongextra{#1year}{}{#1day}}%
+            {\mkbibdateapalongextra{#1year}{#1month}{#1day}}%
+          \dateeraprint{#1year}%
+          \dateuncertainprint
+          \iffieldundef{#1endyear}%
+            {}%
+            {\iffieldequalstr{#1endyear}{}% open-ended range?
+              {\mbox{\bibdatedash}}
+              {\bibdatedash%
+               \iffieldsequal{#1year}{#1endyear}%
+                 {\mkbibdateapalongextra{}{#1endmonth}{#1endday}}
+                 {\mkbibdateapalongextra{#1endyear}{#1endmonth}{#1endday}%
+                  \dateeraprint{#1endyear}}}%
+             \enddateuncertainprint}}}%
+    \endgroup}%
+  \savecommand\mkdaterangeapalong
+  \savecommand\mkdaterangeapalongextra
+  \def\mkdaterangeapalong{%
+    \apa@lbx@de@mkdaterangeapalong}%
+  \def\mkdaterangeapalongextra#1{%
+    \apa@lbx@de@mkdaterangeapalongextra{#1}}%
+}
+
+\UndeclareBibliographyExtras{%
+  \restorecommand\mkdaterangeapalong
+  \restorecommand\mkdaterangeapalongextra
+}
 
 
 %

--- a/tex/latex/biblatex-apa/lbx/ngerman-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/ngerman-apa.lbx
@@ -71,56 +71,123 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addcomma\space}}%  <- change here
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extradate}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \printfield{extradate}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addcomma\space}}%  <- change here
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongmdy#1#2#3{%
     \iffieldundef{#3}%
       {}%
-      {\stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}}%
     \iffieldundef{#2}%
       {}%
       {\iffieldundef{#3}%
         {}%
-        {\adddot\addspace}%
+        {\addspace}%
        \mkbibmonth{\thefield{#2}}}%
     \iffieldundef{#1}%
       {}%
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}%
+  \def\apa@lbx@de@mkdaterangeapalong#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\datecircaprint
+         \ifstrequal{#1}{url}% URL dates are unlikely to be BCE ...
+           {\printtext{%
+               \iffieldsequal{#1year}{#1endyear}
+                 {\iffieldsequal{#1month}{#1endmonth}
+                    {\mkbibdateapalongmdy{}{}{#1day}}
+                    {\mkbibdateapalongmdy{}{#1month}{#1day}}}
+                 {\mkbibdateapalongmdy{#1year}{#1month}{#1day}}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \mkbibdateapalongmdy{#1endyear}{#1endmonth}{#1endday}}}%
+               \dateuncertainprint}}
+           {\printtext{%
+               \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+                 {\mkbibdateapalong{#1year}{}{#1day}}%
+                 {\mkbibdateapalong{#1year}{#1month}{#1day}}%
+               \dateeraprint{#1year}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \iffieldsequal{#1year}{#1endyear}%
+                      {\mkbibdateapalong{}{#1endmonth}{#1endday}}%
+                      {\mkbibdateapalong{#1endyear}{#1endmonth}{#1endday}%
+                     \dateeraprint{#1endyear}}}%
+                 \enddateuncertainprint}}}}%
+    \endgroup}%
+  \def\apa@lbx@de@mkdaterangeapalongextra#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\printtext{%
+          \datecircaprint
+          \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+            {\mkbibdateapalongextra{#1year}{}{#1day}}%
+            {\mkbibdateapalongextra{#1year}{#1month}{#1day}}%
+          \dateeraprint{#1year}%
+          \dateuncertainprint
+          \iffieldundef{#1endyear}%
+            {}%
+            {\iffieldequalstr{#1endyear}{}% open-ended range?
+              {\mbox{\bibdatedash}}
+              {\bibdatedash%
+               \iffieldsequal{#1year}{#1endyear}%
+                 {\mkbibdateapalongextra{}{#1endmonth}{#1endday}}
+                 {\mkbibdateapalongextra{#1endyear}{#1endmonth}{#1endday}%
+                  \dateeraprint{#1endyear}}}%
+             \enddateuncertainprint}}}%
+    \endgroup}%
+  \savecommand\mkdaterangeapalong
+  \savecommand\mkdaterangeapalongextra
+  \def\mkdaterangeapalong{%
+    \apa@lbx@de@mkdaterangeapalong}%
+  \def\mkdaterangeapalongextra#1{%
+    \apa@lbx@de@mkdaterangeapalongextra{#1}}%
+}
 
+\UndeclareBibliographyExtras{%
+  \restorecommand\mkdaterangeapalong
+  \restorecommand\mkdaterangeapalongextra
+}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tex/latex/biblatex-apa/lbx/nswissgerman-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/nswissgerman-apa.lbx
@@ -71,55 +71,123 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extradate}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \printfield{extradate}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongmdy#1#2#3{%
     \iffieldundef{#3}%
       {}%
-      {\stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}}%
     \iffieldundef{#2}%
       {}%
       {\iffieldundef{#3}%
         {}%
-        {\adddot\addspace}%
+        {\addspace}%
        \mkbibmonth{\thefield{#2}}}%
     \iffieldundef{#1}%
       {}%
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}%
+  \def\apa@lbx@de@mkdaterangeapalong#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\datecircaprint
+         \ifstrequal{#1}{url}% URL dates are unlikely to be BCE ...
+           {\printtext{%
+               \iffieldsequal{#1year}{#1endyear}
+                 {\iffieldsequal{#1month}{#1endmonth}
+                    {\mkbibdateapalongmdy{}{}{#1day}}
+                    {\mkbibdateapalongmdy{}{#1month}{#1day}}}
+                 {\mkbibdateapalongmdy{#1year}{#1month}{#1day}}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \mkbibdateapalongmdy{#1endyear}{#1endmonth}{#1endday}}}%
+               \dateuncertainprint}}
+           {\printtext{%
+               \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+                 {\mkbibdateapalong{#1year}{}{#1day}}%
+                 {\mkbibdateapalong{#1year}{#1month}{#1day}}%
+               \dateeraprint{#1year}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \iffieldsequal{#1year}{#1endyear}%
+                      {\mkbibdateapalong{}{#1endmonth}{#1endday}}%
+                      {\mkbibdateapalong{#1endyear}{#1endmonth}{#1endday}%
+                     \dateeraprint{#1endyear}}}%
+                 \enddateuncertainprint}}}}%
+    \endgroup}%
+  \def\apa@lbx@de@mkdaterangeapalongextra#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\printtext{%
+          \datecircaprint
+          \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+            {\mkbibdateapalongextra{#1year}{}{#1day}}%
+            {\mkbibdateapalongextra{#1year}{#1month}{#1day}}%
+          \dateeraprint{#1year}%
+          \dateuncertainprint
+          \iffieldundef{#1endyear}%
+            {}%
+            {\iffieldequalstr{#1endyear}{}% open-ended range?
+              {\mbox{\bibdatedash}}
+              {\bibdatedash%
+               \iffieldsequal{#1year}{#1endyear}%
+                 {\mkbibdateapalongextra{}{#1endmonth}{#1endday}}
+                 {\mkbibdateapalongextra{#1endyear}{#1endmonth}{#1endday}%
+                  \dateeraprint{#1endyear}}}%
+             \enddateuncertainprint}}}%
+    \endgroup}%
+  \savecommand\mkdaterangeapalong
+  \savecommand\mkdaterangeapalongextra
+  \def\mkdaterangeapalong{%
+    \apa@lbx@de@mkdaterangeapalong}%
+  \def\mkdaterangeapalongextra#1{%
+    \apa@lbx@de@mkdaterangeapalongextra{#1}}%
+}
+
+\UndeclareBibliographyExtras{%
+  \restorecommand\mkdaterangeapalong
+  \restorecommand\mkdaterangeapalongextra
+}
 
 
 %

--- a/tex/latex/biblatex-apa/lbx/swissgerman-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/swissgerman-apa.lbx
@@ -71,55 +71,123 @@
   \protected\def\mkbibdateapalong#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongextra#1#2#3{%
     \iffieldundef{#1}%
       {}%
-      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}\printfield{extradate}}%
+      {\iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}%
+       \printfield{extradate}%
+       \ifboolexpr{test {\iffieldundef{#3}} and test {\iffieldundef{#2}}}
+         {}
+         {\addcomma\space}}%
     \iffieldundef{#3}%
       {}%
-      {\iffieldundef{#1}%
-        {}
-        {\addcomma\addspace}%
-       \stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}%
+       \iffieldundef{#2}
+         {}
+         {\addspace}}%
     \iffieldundef{#2}%
       {}%
-      {\iffieldundef{#3}
-        {\iffieldundef{#1}
-          {}
-          {\addspace}}%
-        {\adddot\addspace}%
-       \mkbibmonth{\thefield{#2}}}}%
+      {\mkbibmonth{\thefield{#2}}}}%
   \protected\def\mkbibdateapalongmdy#1#2#3{%
     \iffieldundef{#3}%
       {}%
-      {\stripzeros{\thefield{#3}}}%
+      {\mkbibordinal{\thefield{#3}}}%
     \iffieldundef{#2}%
       {}%
       {\iffieldundef{#3}%
         {}%
-        {\adddot\addspace}%
+        {\addspace}%
        \mkbibmonth{\thefield{#2}}}%
     \iffieldundef{#1}%
       {}%
       {\iffieldundef{#2}%
         {}%
         {\addspace}%
-       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}}
+       \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}{\thefield{#1}}}}%
+  \def\apa@lbx@de@mkdaterangeapalong#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\datecircaprint
+         \ifstrequal{#1}{url}% URL dates are unlikely to be BCE ...
+           {\printtext{%
+               \iffieldsequal{#1year}{#1endyear}
+                 {\iffieldsequal{#1month}{#1endmonth}
+                    {\mkbibdateapalongmdy{}{}{#1day}}
+                    {\mkbibdateapalongmdy{}{#1month}{#1day}}}
+                 {\mkbibdateapalongmdy{#1year}{#1month}{#1day}}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \mkbibdateapalongmdy{#1endyear}{#1endmonth}{#1endday}}}%
+               \dateuncertainprint}}
+           {\printtext{%
+               \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+                 {\mkbibdateapalong{#1year}{}{#1day}}%
+                 {\mkbibdateapalong{#1year}{#1month}{#1day}}%
+               \dateeraprint{#1year}%
+               \iffieldundef{#1endyear}%
+                 {}%
+                 {\iffieldequalstr{#1endyear}{}% open-ended range?
+                   {\mbox{\bibdatedash}}
+                   {\bibdatedash%
+                    \iffieldsequal{#1year}{#1endyear}%
+                      {\mkbibdateapalong{}{#1endmonth}{#1endday}}%
+                      {\mkbibdateapalong{#1endyear}{#1endmonth}{#1endday}%
+                     \dateeraprint{#1endyear}}}%
+                 \enddateuncertainprint}}}}%
+    \endgroup}%
+  \def\apa@lbx@de@mkdaterangeapalongextra#1{%
+    \begingroup
+      \blx@metadateinfo{#1}%
+      \iffieldundef{#1year}{}
+        {\printtext{%
+          \datecircaprint
+          \ifboolexpr{test {\iffieldsequal{#1year}{#1endyear}}
+                           and test {\iffieldsequal{#1month}{#1endmonth}}}
+            {\mkbibdateapalongextra{#1year}{}{#1day}}%
+            {\mkbibdateapalongextra{#1year}{#1month}{#1day}}%
+          \dateeraprint{#1year}%
+          \dateuncertainprint
+          \iffieldundef{#1endyear}%
+            {}%
+            {\iffieldequalstr{#1endyear}{}% open-ended range?
+              {\mbox{\bibdatedash}}
+              {\bibdatedash%
+               \iffieldsequal{#1year}{#1endyear}%
+                 {\mkbibdateapalongextra{}{#1endmonth}{#1endday}}
+                 {\mkbibdateapalongextra{#1endyear}{#1endmonth}{#1endday}%
+                  \dateeraprint{#1endyear}}}%
+             \enddateuncertainprint}}}%
+    \endgroup}%
+  \savecommand\mkdaterangeapalong
+  \savecommand\mkdaterangeapalongextra
+  \def\mkdaterangeapalong{%
+    \apa@lbx@de@mkdaterangeapalong}%
+  \def\mkdaterangeapalongextra#1{%
+    \apa@lbx@de@mkdaterangeapalongextra{#1}}%
+}
+
+\UndeclareBibliographyExtras{%
+  \restorecommand\mkdaterangeapalong
+  \restorecommand\mkdaterangeapalongextra
+}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
German dates require a different logic for comp dates since the order
is different from American-style dates.
Grouped \blx@metadateinfo.

Test against
```latex
\documentclass{article}
\usepackage[ngerman]{babel}
\usepackage{csquotes}
\usepackage{filecontents}
\begin{filecontents*}{\jobname.bib} 
@ARTICLE{7.01:8,
  AUTHOR         = {Richard Clay},
  TITLE          = {Science vs. Ideology},
  SUBTITLE       = {Psychologists Fight Back About the Misuse of Research},
  JOURNALTITLE   = {Monitor on Psychology},
  VOLUME         = {39},
  NUMBER         = {6},
  DATE           = {2008-06},
  URL            = {http://www.apa.org/monitor/},
}
@ARTICLE{7.01:8de,
  AUTHOR         = {Richard Clay},
  TITLE          = {Science vs. Ideology},
  SUBTITLE       = {Psychologists Fight Back About the Misuse of Research},
  JOURNALTITLE   = {Monitor on Psychology},
  VOLUME         = {39},
  NUMBER         = {6},
  DATE           = {2008-06},
  URL            = {http://www.apa.org/monitor/},
  URLDATE           = {2008-06},
}
@ARTICLE{7.01:8deday,
  AUTHOR         = {Richard Clay},
  TITLE          = {Science vs. Ideology},
  SUBTITLE       = {Psychologists Fight Back About the Misuse of Research},
  JOURNALTITLE   = {Monitor on Psychology},
  VOLUME         = {39},
  NUMBER         = {6},
  DATE           = {2008-06-05},
  URLDATE           = {2008-06-05},
  URL            = {http://www.apa.org/monitor/},
}
@ARTICLE{7.01:8derangeday,
  AUTHOR         = {Richard Clay},
  TITLE          = {Science vs. Ideology},
  SUBTITLE       = {Psychologists Fight Back About the Misuse of Research},
  JOURNALTITLE   = {Monitor on Psychology},
  VOLUME         = {39},
  NUMBER         = {6},
  DATE           = {2008-06-05/2008-06-07},
  URLDATE           = {2008-06-05/2008-06-07},
  URL            = {http://www.apa.org/monitor/},
}
@ARTICLE{7.01:8derangemonth,
  AUTHOR         = {Richard Clay},
  TITLE          = {Science vs. Ideology},
  SUBTITLE       = {Psychologists Fight Back About the Misuse of Research},
  JOURNALTITLE   = {Monitor on Psychology},
  VOLUME         = {39},
  NUMBER         = {6},
  DATE           = {2008-06-05/2008-07-05},
  URL            = {http://www.apa.org/monitor/},
  URLDATE           = {2008-06-05/2008-07-05},
}
@ARTICLE{7.01:8derangeyear,
  AUTHOR         = {Richard Clay},
  TITLE          = {Science vs. Ideology},
  SUBTITLE       = {Psychologists Fight Back About the Misuse of Research},
  JOURNALTITLE   = {Monitor on Psychology},
  VOLUME         = {39},
  NUMBER         = {6},
  DATE           = {2008-06-05/2009-07-05},
  URL            = {http://www.apa.org/monitor/},
  URLDATE           = {2008-06-05/2009-07-05},
}
\end{filecontents*}

\usepackage[backend=biber,style=apa]{biblatex}
\addbibresource{\jobname.bib} 

\begin{document}
\textcite{7.01:8de,7.01:8deday,7.01:8derangeday,7.01:8derangemonth,7.01:8derangeyear}
\printbibliography
\end{document}
```

to see the difference. The test files shows that even for `american` the URL date ranges can look off (but then again, URL dates should probably never be ranges).

I suspect many other localisations that don't use American-style dates will also need changes.