### PR TITLE
Shorten name:apa:gievn-family

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -790,28 +790,18 @@
      \ifdefvoid{#5}{}{\addcomma\bibnamedelimd\mkbibnamesuffix{#5}\isdot}}}
 
 \newbibmacro*{name:apa:given-family}[5]{%
-  \ifuseprefix
-    {\usebibmacro{name:delim}{#2}%
-     \usebibmacro{name:hook}{#2}%
-     \ifdefvoid{#2}{}{\mkbibnamegiven{#3}\isdot%
-                      \ifthenelse{\value{uniquename}>1}
-                        {\bibnamedelimd\mkbibbrackets{#2}}
-                        {}%
-                      \bibnamedelimd}%
-     \ifdefvoid{#4}{}{%
-       \mkbibnameprefix{#4}\isdot%
-       \ifprefchar{}{\bibnamedelimc}}%
-     \mkbibnamefamily{#1}\isdot%
-     \ifdefvoid{#5}{}{\bibnamedelimd\mkbibnamesuffix{#5}\isdot}}
-    {\usebibmacro{name:delim}{#1}%
-     \usebibmacro{name:hook}{#1}%
-     \ifdefvoid{#2}{}{\mkbibnamegiven{#3}\isdot%
-                      \ifthenelse{\value{uniquename}>1}
-                        {\bibnamedelimd\mkbibbrackets{#2}}
-                        {}%
-                      \bibnamedelimd}%
-     \mkbibnamefamily{#1}\isdot
-     \ifdefvoid{#5}{}{\addcomma\bibnamedelimd\mkbibnamesuffix{#5}\isdot}}}
+  \usebibmacro{name:delim}{#2#4#1#5}%
+  \usebibmacro{name:hook}{#2#4#1#5}%
+  \ifdefvoid{#2}{}{\mkbibnamegiven{#3}\isdot%
+                   \ifthenelse{\value{uniquename}>1}
+                     {\bibnamedelimd\mkbibbrackets{#2}}
+                     {}%
+                   \bibnamedelimd}%
+  \ifdefvoid{#4}{}{%
+    \mkbibnameprefix{#4}\isdot
+    \ifprefchar{}{\bibnamedelimc}}%
+  \mkbibnamefamily{#1}\isdot%
+  \ifdefvoid{#5}{}{\bibnamedelimd\mkbibnamesuffix{#5}\isdot}}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Code from the `useprefix=true` branch is unchanged except for more arguments to `name:delim` and `name:hook` and one unnecessary `%`. The `usprefix=false` branch can be gotten rid of entirely.