### PR TITLE
Use doi.org instead of legacy dx.doi.org

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -2152,7 +2152,7 @@
 \DeclareFieldFormat{doi}{%
   doi\addcolon
   \ifhyperref
-    {\href{https://dx.doi.org/#1}{\nolinkurl{#1}}}
+    {\href{https://doi.org/#1}{\nolinkurl{#1}}}
     {\nolinkurl{#1}}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
  The use of doi.org is the preferred and recommended form of the DOI
  HTTP proxy and HTTPS is preferred over HTTP; however, dx.doi.org
  remains fully supported.

  -- https://www.doi.org/factsheets/DOI_OpenURL.html