### PR TITLE
Remove apabackref option (#72)

### DIFF
--- a/doc/biblatex-apa6.tex
+++ b/doc/biblatex-apa6.tex
@@ -251,16 +251,6 @@ The following options are set as usual in the options passed to
 |biblatex|.
 
 \begin{ltxcode}
-apabackref=true|false
-\end{ltxcode}% | stupid comment to stop emacs highlighting as verb due
-             % to single pipe
-
-\noindent It is not APA style to include backreferences in the References to
-pages where citations of the entry occur. However, this is very
-useful, especially in proofing and so if you set the |apabackref|
-option to «true», these are enabled. The default is «false».
-
-\begin{ltxcode}
 apamaxprtauth=<num>
 \end{ltxcode}
 
@@ -467,6 +457,10 @@ applied to the data stream by |biber| and does not change your \file{.bib}.
 \section{Revision history}\label{rev}
 
 \begin{changelog}
+\begin{release}{8.2}{2019-??-??}
+\item Removed |apabackref| option, use the standard
+  |biblatex| |backref| option instead
+\end{release}
 
 \begin{release}{8.1}{2019-11-27}
 \item Corrected documentation for legacy 6th edition style

--- a/tex/latex/biblatex-apa/bbx/apa6.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa6.bbx
@@ -251,7 +251,7 @@
 \ExecuteBibliographyOptions{%
                             abbreviate=true,%
                             autocite=inline,%
-                            backref=true,%
+                            backref=false,%
                             citetracker=true,%
                             date=apalong,%
                             dateabbrev=false,%
@@ -295,18 +295,6 @@
   }
 }
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% It is not APA standard to have backrefs in the bib
-% Some users might like it though.
-
-\newbool{apa:backref}
-\DeclareBibliographyOption{apabackref}{%
-  \ifstrequal{#1}{true}
-    {\global\booltrue{apa:backref}}
-    {\global\boolfalse{apa:backref}}}
-
-%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % (APA 6.29) Additional material sometimes goes in parens
@@ -1348,7 +1336,7 @@
      \usebibmacro{related}}
     {}%
   \usebibmacro{apa:finpunct}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{finentry}}
 
 \DeclareBibliographyDriver{newsarticle}{%
@@ -1375,7 +1363,7 @@
      \usebibmacro{related}}
     {}%
   \usebibmacro{apa:finpunct}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{finentry}}
 
 \DeclareBibliographyDriver{book}{%
@@ -1401,7 +1389,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1428,7 +1416,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1461,7 +1449,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1486,7 +1474,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1517,7 +1505,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1548,7 +1536,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1590,7 +1578,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1621,7 +1609,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1653,7 +1641,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1681,7 +1669,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1710,7 +1698,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1736,7 +1724,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1759,7 +1747,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1786,7 +1774,7 @@
   \usebibmacro{doi+eprint+url}%
   \newunit\newblock
   \printfield{addendum}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1821,7 +1809,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1850,7 +1838,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1877,7 +1865,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1904,7 +1892,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1933,7 +1921,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1962,7 +1950,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -1989,7 +1977,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -2009,7 +1997,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -2029,7 +2017,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}%
   \usebibmacro{finentry}}
 
@@ -2059,7 +2047,7 @@
     {\usebibmacro{related:init}%
      \usebibmacro{related}}
     {}%
-  \usebibmacro{apa:pageref}%
+  \usebibmacro{pageref}%
   \usebibmacro{apa:finpunct}
   \usebibmacro{finentry}}
 
@@ -2175,14 +2163,6 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Wrapper for backrefs
-
-\newbibmacro{apa:pageref}{%
-  \ifbool{apa:backref}{\usebibmacro{pageref}}{}}
-
-%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %


### PR DESCRIPTION
Ports 24a6f584c12580339e8947c4080ffef85aa8ac1e to biblatex-apa6.

See #72.