### PR TITLE
Change Spanish string for retrieved

### DIFF
--- a/tex/latex/biblatex-apa/lbx/spanish-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/spanish-apa.lbx
@@ -132,7 +132,7 @@
   page             = {{P\'agina}{{}p\adddot}},
   pages            = {{P\'aginas}{{}pp\adddot}},
   on               = {{el}{el}},
-  retrieved        = {{Recuperado}{Recuperado}},
+  retrieved        = {{Consultado}{Consultado}},
   available        = {{disponible}{disponible}},
   from             = {{desde}{desde}},
   archivedat       = {{archivado en}{archivado en}},


### PR DESCRIPTION
I think "Consultado" is a more idiomatic option than "Recuperado", which is a literal translation of the English "Retrieved".