### PR TITLE
Tweak example bib files

### DIFF
--- a/bibtex/bib/biblatex-apa-test-citations.bib
+++ b/bibtex/bib/biblatex-apa-test-citations.bib
@@ -508,10 +508,10 @@
 % Test "and others"
 @ARTICLE{ao1,
   AUTHOR         = {Boker, S. and Neale, M. and Maes, H. and Wilde, M. and
-                   Spiegel, M. and Brick, T. and Spies, J. and Estabrook,
-                   R. and Kenny, S. and Bates, T. and others},
-  TITLE          = {Open{M}x: {A}n open source extended structural
-                   equation modeling framework},
+                    Spiegel, M. and Brick, T. and Spies, J. and Estabrook,
+                    R. and Kenny, S. and Bates, T. and others},
+  TITLE          = {{OpenMx}: {An} open source extended structural
+                    equation modeling framework},
   JOURNAL        = {Psychometrika},
   VOLUME         = {76},
   NUMBER         = {2},
@@ -545,13 +545,13 @@
 
 % Testing citation with complete dates
 @ARTICLE{Ludwig2014,
- ENTRYSUBTYPE  = {nonacademic},
- AUTHOR = {Ludwig, Jan},
- TITLE = {Wenn nichts mehr geht},
- URL = {http://www.zeit.de/campus/2014/06/pruefungsergebnis-klage},
- JOURNALTITLE = {Zeit Campus},
- DATE = {2014-10-08},
- LANGUAGE = {de}
+  ENTRYSUBTYPE  = {nonacademic},
+  AUTHOR        = {Ludwig, Jan},
+  TITLE         = {Wenn nichts mehr geht},
+  URL           = {http://www.zeit.de/campus/2014/06/pruefungsergebnis-klage},
+  JOURNALTITLE  = {Zeit Campus},
+  DATE          = {2014-10-08},
+  LANGUAGE      = {de}
 }
 
 % Testing date range with same months, different days

--- a/bibtex/bib/biblatex-apa-test-references.bib
+++ b/bibtex/bib/biblatex-apa-test-references.bib
@@ -390,7 +390,7 @@
 }
 
 % (APA 9.51)
-@INBOOK{9.51:1,
+@INCOLLECTION{9.51:1,
   AUTHOR         = {L. K. Barber and M. J. Grawitch and P. W. Maloney},
   EDITOR         = {M. J. Grawitch and D. W. Ballard},
   TITLE          = {Work-life Balance},
@@ -461,11 +461,11 @@
   KEYWORDS       = {meta}
 }
 
-@INBOOK{9.52:2,
+@INCOLLECTION{9.52:2,
   AUTHOR         = {J. R. Finley and J. G. Tullis and A. S. Benjamin},
   EDITOR         = {M. S. Khine and I. M. Saleh},
   TITLE          = {Metacognitive Control of Learning and Remembering},
-  BOOKTITLE      = {New Science of Learning},  
+  BOOKTITLE      = {New Science of Learning},
   BOOKSUBTITLE   = {Cognition, Computers and Collaboration in Education},
   PAGES          = {109--131},
   PUBLISHER      = {Springer},
@@ -581,7 +581,8 @@
 @ARTICLE{10.1:5,
   AUTHOR         = {De Vries, R. and M. Nieuwenhuijze and S. E. Buitendijk
                     and {the members of Midwifery Science Work Group}},
-  TITLE          = {What Does It Take To Have a Strong and Independent Profession of Midwifery? {L}essons From the {N}etherlands},
+  TITLE          = {What Does It Take To Have a Strong and Independent Profession of Midwifery?
+                    {Lessons} From the {Netherlands}},
   JOURNALTITLE   = {Midwifery},
   VOLUME         = {29},
   NUMBER         = {10},
@@ -607,9 +608,9 @@
 % (APA 10.1 Example 7)
 @ARTICLE{10.1:7,
   AUTHOR         = {S. M. Huestegge and T. Raettig and L. Huestegge},
-  TITLE          = {Are Face-incongruent Voices Harder to Process? {E}ffects
-                    of Face-Voice Gender Incongruity on Basic Cognitive
-                    Information Processing},
+  TITLE          = {Are Face-incongruent Voices Harder to Process?
+                    {Effects} of Face-Voice Gender Incongruity on
+                    Basic Cognitive Information Processing},
   JOURNALTITLE   = {Experimental Psychology},
   HOWPUBLISHED   = {Advance online publication},
   DATE           = {2019},
@@ -660,7 +661,7 @@
 @ARTICLE{10.1:11,
   AUTHOR         = {M. F. Shore},
   TITLE          = {Marking Time in the Land Of Plenty},
-  SUBTITLE       = {Reflections on Mental Health in the {U}nited {S}tates},
+  SUBTITLE       = {Reflections on Mental Health in the {United} {States}},
   JOURNALTITLE   = {American Journal of Orthopsychiatry},
   VOLUME         = {84},
   NUMBER         = {6},
@@ -673,7 +674,7 @@
 
 @ARTICLE{10.1:11r,
   TITLE          = {Marking Time in the Land Of Plenty},
-  SUBTITLE       = {Reflections on Mental Health in the {U}nited {S}tates},
+  SUBTITLE       = {Reflections on Mental Health in the {United} {States}},
   JOURNALTITLE   = {American Journal of Orthopsychiatry},
   VOLUME         = {51},
   NUMBER         = {3},
@@ -743,7 +744,7 @@
 @ARTICLE{10.1:15b,
   AUTHOR         = {M. Bustillos},
   TITLE          = {On Video Games and Storytelling},
-  SUBTITLE       = {An Interview with {T}om {B}issell},
+  SUBTITLE       = {An Interview with {Tom} {Bissell}},
   JOURNALTITLE   = {The New Yorker},
   KEYWORDS       = {nonacademic},
   DATE           = {2013-03-19},
@@ -764,7 +765,8 @@
 % (APA 10.1 Example 16)
 @ARTICLE{10.1:16a,
   AUTHOR         = {B. Guarino},
-  TITLE          = {How Will Humanity React to Alien Life? {P}sychologists Have Some Predictions},
+  TITLE          = {How Will Humanity React to Alien Life?
+                    {Psychologists} Have Some Predictions},
   JOURNALTITLE   = {The Washington Post},
   KEYWORDS       = {nonacademic},
   DATE           = {2017-12-04},
@@ -891,7 +893,7 @@
 }
 
 % (APA 10.2 Example 24)
-@BOOK{10.2:24,
+@COLLECTION{10.2:24,
   EDITOR         = {Schmid, Henry-James},
   TITLE          = {Entrenchment and the Psychology of Language Learning},
   SUBTITLE       = {How we Reorganize and Adapt Linguistic Knowledge},
@@ -901,7 +903,7 @@
 }
 
 % (APA 10.2 Example 25)
-@BOOK{10.2:25,
+@COLLECTION{10.2:25,
   EDITOR         = {Hacker Hughes, J.},
   TITLE          = {Military Veteran Psychological Health and Social Care},
   SUBTITLE       = {Contemporary Approaches},
@@ -910,7 +912,7 @@
 }
 
 % (APA 10.2 Example 26)
-@BOOK{10.2:26,
+@COLLECTION{10.2:26,
   EDITOR         = {K. F. Pridham and R. Limbo and M. Schroeder},
   TITLE          = {Guided Participation in Pediatric Nursing Practice},
   SUBTITLE       = {Relationship-based Teaching and Learning with Parents, Children and Adolescents},
@@ -922,7 +924,7 @@
 % (APA 10.2 Example 27)
 @BOOK{10.2:27a,
   AUTHOR         = {N. Amano and H. Kondo},
-  TITLE          = {Lexical Characteristics of {J}apanese Language},
+  TITLE          = {Lexical Characteristics of {Japanese} Language},
   ORIGTITLE      = {Nihongo no goi tokusei},
   PUBLISHER      = {Sansei-do},
   VOLUME         = {7},
@@ -963,7 +965,7 @@
 @BOOK{10.2:29b,
   AUTHOR         = {J. K. Rowling},
   NARRATOR       = {J. Dale},
-  TITLE          = {Harry {P}otter and the Sorceror's Stone},
+  TITLE          = {Harry {Potter} and the Sorceror's Stone},
   TITLEADDON     = {Audiobook},
   PUBLISHER      = {Pottermore Publishing},
   DATE           = {2015},
@@ -982,7 +984,7 @@
   DOI            = {10.1002/9780470561119}
 }
 
-@BOOK{10.2:30b,
+@COLLECTION{10.2:30b,
   EDITOR         = {C. B. Travis and J. W. White},
   TITLE          = {{APA} Handbook of the Psychology of Women},
   SUBTITLE       = {Vol. 1. History, theory, and Battlegrounds},
@@ -1034,14 +1036,14 @@
 
 @BOOK{10.2:33b,
   GROUPAUTHOR    = {{Merriam-Webster}},
-  TITLE          = {{M}erriam-{W}ebster.com Dictionary},
+  TITLE          = {{Merriam-Webster.com} Dictionary},
   URL            = {https://www.merriam-webster.com/},
   URLDATE        = {2019-05-05}
 }
 
-@BOOK{10.2:33c,
+@REFERENCE{10.2:33c,
   EDITOR         = {E. N. Zalta},
-  TITLE          = {The {S}tanford Encyclopedia of Philosophy},
+  TITLE          = {The {Stanford} Encyclopedia of Philosophy},
   EDITION        = {Summer 2019 ed.},
   URL            = {https://plato.stanford.edu/archives/sum2019/},
   PUBLISHER      = {Stanford University},
@@ -1049,10 +1051,10 @@
 }
 
 % (APA 10.2 Example 34)
-@BOOK{10.2:34,
+@COLLECTION{10.2:34,
   EDITOR         = {M. Gold},
   TITLE          = {The Complete Social Scientist},
-  SUBTITLE       = {A {K}urt {L}ewin Reader},
+  SUBTITLE       = {A {Kurt} {Lewin} Reader},
   PUBLISHER      = {American Psychological Association},
   DATE           = {1999},
   DOI            = {10.1037/10319-000}
@@ -1061,7 +1063,7 @@
 % (APA 10.2 Example 35)
 % No AUTHOR or GROUPAUTHOR - title goes in author position
 @BOOK{10.2:35a,
-  TITLE           = {{K}ing {J}ames {B}ible},
+  TITLE           = {{King} {James} {Bible}},
   DATE            = {2017},
   ORIGDATE        = {1769},
   URLDESCRIPTION  = {King James Bible Online},
@@ -1069,15 +1071,15 @@
 }
 
 @BOOK{10.2:35b,
-  TITLE          = {The {Q}ur'an},
+  TITLE          = {The {Qur'an}},
   TRANSLATOR     = {Abdel Haleem, M. A. S.},
   PUBLISHER      = {Oxford University Press},
   DATE           = {2004}
 }
 
 @BOOK{10.2:35c,
-  TITLE          = {{T}he {T}orah},
-  SUBTITLE       = {The Five Books of {M}oses},
+  TITLE          = {{The} {Torah}},
+  SUBTITLE       = {The Five Books of {Moses}},
   EDITION        = {3},
   PUBLISHER      = {The Jewish Publication Society},
   DATE           = {2015},
@@ -1109,7 +1111,7 @@
 }
 
 % (APA 10.3 Example 38)
-@INBOOK{10.3:38,
+@INCOLLECTION{10.3:38,
   AUTHOR         = {K. F. Balsam and C. R. Martell and K. P. Jones and S. A. Safren},
   EDITOR         = {G. Y. Iwamasa and P. A. Hays},
   TITLE          = {Affirmative Cognitive Behaviour Therapy with Sexual and
@@ -1124,7 +1126,7 @@
 }
 
 % (APA 10.3 Example 39)
-@INBOOK{10.3:39,
+@INCOLLECTION{10.3:39,
   AUTHOR         = {R. Weinstock and G. B. Leong and J. A. Silva},
   EDITOR         = {R. Rosner},
   TITLE          = {Defining Forensic Psychiatry},
@@ -1137,11 +1139,11 @@
 }
 
 % (APA 10.3 Example 40)
-@INBOOK{10.3:40,
+@INCOLLECTION{10.3:40,
   AUTHOR         = {N. Tafoya and Del Vecchio, A.},
   EDITOR         = {M. McGoldrick and J. Giordano and N. Garcia-Preto},
   TITLE          = {Back to the Future},
-  SUBTITLE       = {An Examination of the {N}ative {A}merican {H}olocaust experience},
+  SUBTITLE       = {An Examination of the {Native} {American} {Holocaust} experience},
   BOOKTITLE      = {Ethnicity and Family Therapy},
   EDITION        = {3},
   PAGES          = {55--63},
@@ -1151,14 +1153,14 @@
 }
 
 % (APA 10.3 Example 41)
-@INBOOK{10.3:41,
+@INCOLLECTION{10.3:41,
   AUTHOR         = {Carcavilla González, N.},
   EDITOR         = {Garcia Meilán, J. J.},
   TITLE          = {Auditory Sensory Therapy},
   SUBTITLE       = {Brain Activation Through Music},
-  ORIGTITLE      = {Terapia senorial auditiva: {A}ctivation cerebral por
+  ORIGTITLE      = {Terapia senorial auditiva: {Activation} cerebral por
                     medio de la música},
-  BOOKTITLE      = {Guía práctica de terapias estimulativas en el {A}lzhéimer},
+  BOOKTITLE      = {Guía práctica de terapias estimulativas en el {Alzhéimer}},
   PAGES          = {67--86},
   PUBLISHER      = {Editorial Síntesis},
   DATE           = {2015},
@@ -1180,7 +1182,7 @@
 
 % (APA 10.3 Example 43)
 % Note that this done with the related entries functionality supported by Biber
-@INBOOK{10.3:43,
+@INCOLLECTION{10.3:43,
   AUTHOR         = {C. Sacchett and G. W. Humphreys},
   EDITOR         = {D. A. Balota and E. J. Marsh},
   TITLE          = {Calling a Squirrel and Squirrel but a Canoe a Wigwam},
@@ -1209,7 +1211,7 @@
 }
 
 % (APA 10.3 Example 44)
-@INBOOK{10.3:44,
+@INCOLLECTION{10.3:44,
   AUTHOR         = {U. Bronfenbrenner},
   EDITOR         = {U. Bronfenbrenner},
   TITLE          = {The Social Ecology of Human Development},
@@ -1233,12 +1235,12 @@
 }
 
 % (APA 10.3 Example 45)
-@INBOOK{10.3:45,
+@INCOLLECTION{10.3:45,
   AUTHOR         = {S. Goldin-Meadow},
   EDITOR         = {L. S. Lisben and U. Mueller},
   TITLE          = {Gesture and Cognitive Development},
   BOOKTITLE      = {Handbook of Child Psychology and Developmental Science},
-  BOOKSUBTITLE   = {Vol. 2. {C}ognitive Processes},
+  BOOKSUBTITLE   = {Vol. 2. {Cognitive} Processes},
   EDITION        = {7},
   PAGES          = {339--380},
   PUBLISHER      = {John Wiley \& Sons},
@@ -1247,12 +1249,12 @@
 }
 
 % (APA 10.3 Example 46)
-@INBOOK{10.3:46,
+@INCOLLECTION{10.3:46,
   AUTHOR         = {K. Lewin},
   EDITOR         = {M. Gold},
   TITLE          = {Group Decision and Social Change},
   BOOKTITLE      = {The Complete Social Scientist},
-  BOOKSUBTITLE   = {A {K}urt {L}ewin Reader},
+  BOOKSUBTITLE   = {A {Kurt} {Lewin} Reader},
   PUBLISHER      = {American Psychological Association},
   PAGES          = {265--284},
   DATE           = 1999,
@@ -1272,17 +1274,17 @@
 @INBOOK{10.3:47b,
   GROUPAUTHOR    = {{Merriam-Webster}},
   TITLE          = {Self-report},
-  BOOKTITLE      = {{M}erriam-{W}ebster.com Dictionary},
+  BOOKTITLE      = {{Merriam-Webster.com} Dictionary},
   URL            = {https://www.merriam-webster.com/dictionary/self-report},
   URLDATE        = {2019-07-12}
 }
 
 % (APA 10.3 Example 48)
-@INBOOK{10.3:48,
+@INREFERENCE{10.3:48,
   AUTHOR         = {G. Graham},
   EDITOR         = {E. N. Zalta},
   TITLE          = {Behaviourism},
-  BOOKTITLE      = {The {S}tanford Encyclopedia of Philosophy},
+  BOOKTITLE      = {The {Stanford} Encyclopedia of Philosophy},
   EDITION        = {Summer 2019 ed.},
   URL            = {https://plato.stanford.edu/archives/sum2019/entries/behaviourism},
   PUBLISHER      = {Stanford University},
@@ -1301,7 +1303,7 @@
 @REPORT{10.4:50a,
   GROUPAUTHOR    = {{Australian Government Productivity Commission} and
                     {New Zealand Productivity Commission}},
-  TITLE          = {Strengthening Trans-{T}asman Economic Relations},
+  TITLE          = {Strengthening Trans-{Tasman} Economic Relations},
   URL            = {https://www.pc.gov.au/inquiries/completed/australia-new-zealand/report/trans-tasman.pdf},
   DATE           = {2012}
 }
@@ -1309,8 +1311,8 @@
 @REPORT{10.4:50b,
   GROUPAUTHOR    = {{Canada Council for the Arts}},
   TITLE          = {What We Heard},
-  SUBTITLE       = {Summary of Key Findings: 2013 {C}anada {C}ouncil's
-                    {I}nter-{A}rts {O}ffice Consultation},
+  SUBTITLE       = {Summary of Key Findings: 2013 {Canada} {Council's}
+                    {Inter-Arts} {Office} Consultation},
   URL            = {http://publications.gc.ca/collections/collection_2017/canadacouncil/K23-65-2013-eng.pdf},
   DATE           = {2013}
 }
@@ -1319,7 +1321,7 @@
 % numerical. This detection is automatic.
 @REPORT{10.4:50c,
   GROUPAUTHOR    = {{National Cancer Institute}},
-  TITLE          = {Facing Forward}, 
+  TITLE          = {Facing Forward},
   SUBTITLE       = {Life After Cancer Treatment},
   NUMBER         = {18-2424},
   TYPE           = {NIH Publication},
@@ -1338,7 +1340,7 @@
 
 @REPORT{10.4:51b,
   AUTHOR         = {A. Segaert and A. Bauer},
-  TITLE          = {The Extent and Nature of Veteran Homelessness in {C}anada},
+  TITLE          = {The Extent and Nature of Veteran Homelessness in {Canada}},
   PUBLISHER      = {{Employment and Social Development Canada}},
   URL            = {https://www.canada.ca/en/employment-social-development/programs/communities/homelessness/publications-bulletins/veterans-report.html},
   DATE           = {2015}
@@ -1347,8 +1349,8 @@
 % (APA 10.4 Example 52)
 @REPORT{10.4:52,
   AUTHOR         = {D. L. Blackwell and J. W. Lucas and T. C. Clarke},
-  TITLE          = {Summary Health Statistics for {U}.{S}. Adults},
-  SUBTITLE       = {National {H}ealth {I}nterview {S}urvey, 2012},
+  TITLE          = {Summary Health Statistics for {U.S.} Adults},
+  SUBTITLE       = {National {Health} {Interview} {Survey}, 2012},
   PUBLISHER      = {{Centers for Disease Control and Prevention}},
   ISSUE          = {Vital and Health Statistics Series},
   NUMBER         = {10, Issue 260},
@@ -1359,8 +1361,8 @@
 % (APA 10.4 Example 53)
 @REPORT{10.4:53,
   GROUPAUTHOR    = {{British Cardiovascular Society Working Group}},
-  TITLE          = {British {C}ardiovascular {S}ociety {W}orking {G}roup report},
-  SUBTITLE       = {Out-of-hours Cardiovascular Care: {M}anagement of
+  TITLE          = {British {Cardiovascular} {Society} {Working} {Group} report},
+  SUBTITLE       = {Out-of-hours Cardiovascular Care: {Management} of
                     Cardiac Emergencies and Hospital In-patients},
   PUBLISHER      = {British Cardiovascular Society},
   URL            = {http://www.bcs.com/documents/BCSOOHWP_Final_Report_05092016.pdf},
@@ -1500,7 +1502,7 @@
   TITLE          = {The Art and Significance of Successfully Identifying
                     Resilient Individuals},
   SUBTITLE       = {A Person-Focused Approach},
-  MAINTITLE      = {Perspectives on Resilience: {C}onceptualization,
+  MAINTITLE      = {Perspectives on Resilience: {Conceptualization},
                     Measurement, and Enhancement},
   MAINTITLEADDON = {Symposium},
   EVENTTITLE     = {Western Psychological Association 98th Annual Convention},
@@ -1523,8 +1525,8 @@
   AUTHOR         = {M. M. Hollander},
   TITLE          = {Resistance to Authority},
   SUBTITLE       = {Methodological Innovations and New Lessons from the
-                    {M}ilgram Experiment},
-  TITLEADDON     = {Doctoral Dissertation, {U}niversity of {W}isconsin-{M}adison},
+                    {Milgram} Experiment},
+  TITLEADDON     = {Doctoral Dissertation, {University} of {Wisconsin}--{Madison}},
   PUBLISHER      = {{ProQuest Dissertations and Theses Global}},
   TYPE           = {Publication},
   NUMBER         = {10289373},
@@ -1537,7 +1539,7 @@
   TITLE          = {Dealing with Dual Differences},
   SUBTITLE       = {Social Coping Strategies of Gifted and Lesbian, Gay,
                     Bisexual, Transgender, and Queer Adolescents},
-  TITLEADDON     = {Master's Thesis, {T}he {C}ollege of {W}illiam \& {M}ary},
+  TITLEADDON     = {Master's Thesis, {The} {College} of {William} \& {Mary}},
   PUBLISHER      = {William \& Mary Digital Archive},
   URL            = {https://digitalarchive.wm.edu/bitstream/handle/10288/16594/HutchesonVirginia2012.pdf},
   DATE           = {2012}
@@ -1674,7 +1676,7 @@
 @UNPUBLISHED{10.8:74,
   AUTHOR         = {H-K Ho},
   TITLE          = {Teacher Preparation for Early Childhood Special
-                    Education in {T}aiwan},
+                    Education in {Taiwan}},
   NUMBER         = {ED545393},
   LOCATION       = {ERIC},
   URL            = {https://files.eric.ed.gov/fulltext/ED545393.pdf},
@@ -1697,7 +1699,7 @@
   ENTRYSUBTYPE   = {Data set and code book},
   GROUPAUTHOR    = {{National Center for Education Statistics}},
   TITLE          = {Fast Response Survey System ({FRSS})},
-  SUBTITLE       = {Teacher's Use of Educational Technology in {U}.{S}.
+  SUBTITLE       = {Teacher's Use of Educational Technology in {U.S.}
                     Public Schools, 2009},
   NUMBER         = {ICPSR 35531},
   VERSION        = {V3},
@@ -1709,7 +1711,7 @@
 @DATASET{10.9:75c,
   ENTRYSUBTYPE = {Data set},
   GROUPAUTHOR  = {{Pew Research Center}},
-  TITLE        = {American Trends Panel {W}ave 26},
+  TITLE        = {American Trends Panel {Wave} 26},
   URL          = {https://www.pewsocialtrends.org/dataset/american-trends-panel-wave-26/},
   DATE         = {2018}
 }
@@ -1717,8 +1719,8 @@
 % (APA 10.9 Example 76)
 @DATASET{10.9:76a,
   TITLEADDON   = {Unpublished raw data on the correlations between the
-                  {F}ive {F}acet {M}indfulness {Q}uestionnaire and the {K}entucky
-                  {I}nventory of {M}indfulness {S}kills},
+                  {Five} {Facet} {Mindfulness} {Questionnaire}
+                  and the {Kentucky} {Inventory} of {Mindfulness} {Skills}},
   INSTITUTION    = {University of Kentucky},
   AUTHOR         = {R. A. Baer},
   DATE           = {2015}
@@ -1778,7 +1780,7 @@
 @SOFTWARE{10.10:80,
   ENTRYSUBTYPE   = {Mobile app},
   AUTHOR         = {Epocrates\relax},
-  APPENTRY       = {Interaction Check: {A}spirin + Sertraline},
+  APPENTRY       = {Interaction Check: {Aspirin} + {Sertraline}},
   TITLE          = {Epocrates Medical References},
   VERSION        = {18.12},
   PUBLISHER      = {Google Play Store},
@@ -1789,8 +1791,8 @@
 % (APA 10.11 Example 81)
 @MANUAL{10.11:81,
   AUTHOR         = {A. Tellegen and Y. S. Ben-Porath},
-  TITLE          = {Minnesota {M}ultiphasic {P}ersonality {I}nventory--2
-                    {R}estructured {F}orm ({MMPI-2-RF})},
+  TITLE          = {Minnesota {Multiphasic} {Personality} {Inventory}--2
+                    {Restructured} {Form} ({MMPI-2-RF})},
   SUBTITLE       = {Technical Manual},
   PUBLISHER      = {Pearson},
   DATE           = {2011}
@@ -1799,7 +1801,7 @@
 % (APA 10.11 Example 82)
 @SOFTWARE{10.11:82,
   AUTHOR         = {{Project Implicit}},
-  TITLE          = {Gender-{S}cience {IAT}},
+  TITLE          = {Gender-{Science} {IAT}},
   URL            = {https://implicit.harvard.edi/implicit/takeatest.html}
 }
 
@@ -1808,8 +1810,8 @@
   ENTRYSUBTYPE   = {Database record},
   AUTHOR         = {J. Alonso-Tapia and C. Nieto and E. Merino-Tejedor and
                     J. A. Huertas and M. Ruiz},
-  TITLE          = {Situated {G}oals {Q}uestionnaire for {U}niversity
-                    {S}tudents ({SGQ-U}, {CMS-U})},
+  TITLE          = {Situated {Goals} {Questionnaire} for {University}
+                    {Students} ({SGQ-U}, {CMS-U})},
   PUBLISHER      = {PsycTESTS},
   DOI            = {10.1037/t66267-000},
   DATE           = {2018}
@@ -1818,7 +1820,7 @@
 @SOFTWARE{10.11:83b,
   ENTRYSUBTYPE   = {Database record},
   AUTHOR         = {D. Cardoza and J. K. Morris and H. F. Myers and N. Rodriguez},
-  TITLE          = {Acculturative {S}tress {I}nventory ({ASI})},
+  TITLE          = {Acculturative {Stress} {Inventory} ({ASI})},
   NUMBER         = {TC022704},
   PUBLISHER      = {ETS TestLink},
   DATE           = {2000}
@@ -1890,12 +1892,12 @@
   ENTRYSUBTYPE    = {tvepisode},
   AUTHOR          = {K. Barris},
   AUTHOR+an:role  = {1=director,writer},
-  TITLE           = {Lemons ({S}eason 3, {E}pisode 12)},
+  TITLE           = {Lemons ({Season}~3, {Episode}~12)},
   MAINTITLE       = {Black-ish},
   EXECPRODUCER    = {K. Barris and J. Groff and A. Anderson and E. B.
                      Dobbins and L. Fishburne and H. Sugland},
   PUBLISHER       = {Wilmore Films and Artists First and Cinema Gypsy
-                     Productions and ABC Studios}, 
+                     Productions and ABC Studios},
   DATE            = {2017-01-11}
 }
 
@@ -1905,8 +1907,8 @@
   ENTRYSUBTYPE    = {tvepisode},
   AUTHOR          = {B. Oakley and J. Weinstein and J. Lynch},
   AUTHOR+an:role  = {1=writer;2=writer;3=director},
-  TITLE           = {Who Shot {M}r. {B}urns? ({P}art {O}ne) ({S}eason 6,
-                     {E}pisode 25)},
+  TITLE           = {Who Shot {Mr.} {Burns}? ({Part} {One}) ({Season}~6,
+                     {Episode}~25)},
   MAINTITLE       = {The Simpsons},
   EXECPRODUCER    = {D. Mirkin and J. L. Brooks and M. Groening and S. Simon},
   PUBLISHER       = {Gracie Films and Twentieth Century Fox Film Corporation},
@@ -1919,7 +1921,7 @@
   ENTRYSUBTYPE    = {video},
   AUTHOR          = {S. Giertz},
   TITLE           = {Why You Should Make Useless Things},
-  PUBLISHER       = {TED Conferences}, 
+  PUBLISHER       = {TED Conferences},
   DATE            = {2018-04},
   URL             = {https://www.ted.com/talks/simone_giertz_why_you_should_make_useless_things}
 }
@@ -1928,9 +1930,9 @@
 @VIDEO{10.12:88b,
   ENTRYSUBTYPE    = {video},
   GROUPAUTHOR     = {TED},
-  TITLE           = {Brené {B}rown},
+  TITLE           = {Brené {Brown}},
   SUBTITLE        = {Listening to Shame},
-  PUBLISHER       = {YouTube}, 
+  PUBLISHER       = {YouTube},
   DATE            = {2012-03-16},
   URL             = {https://www.youtube.com/watch?v=psN1DORYYV0}
 }
@@ -1942,7 +1944,7 @@
   ENTRYSUBTYPE    = {Webinar},
   AUTHOR          = {J. F. Goldberg},
   TITLE           = {Evaluating Adverse Drug Effects},
-  PUBLISHER       = {American Psychiatric Association}, 
+  PUBLISHER       = {American Psychiatric Association},
   DATE            = {2018},
   URL             = {https://education.psychiatry.org/Users/ProductDetails.aspx?ActivityID=6172}
 }
@@ -1953,7 +1955,7 @@
   ENTRYSUBTYPE    = {video},
   AUTHOR          = {S. Cutts},
   TITLE           = {Happiness},
-  PUBLISHER       = {Vimeo}, 
+  PUBLISHER       = {Vimeo},
   DATE            = {2017-11-24},
   URL             = {https://vimeo.com/244405542}
 }
@@ -1965,7 +1967,7 @@
   AUTHOR             = {M. Fogarty},
   AUTHOR+an:username = {1="Grammar Girl"},
   TITLE              = {How to Diagram a Sentence (Absolute Basics)},
-  PUBLISHER          = {YouTube}, 
+  PUBLISHER          = {YouTube},
   DATE               = {2016-09-30},
   URL                = {https://youtube.be/deiEY5Yq1ql}
 }
@@ -1975,7 +1977,7 @@
   ENTRYSUBTYPE       = {video},
   GROUPAUTHOR        = {{University of Oxford}},
   TITLE              = {How Do Geckos Walk on Water?},
-  PUBLISHER          = {YouTube}, 
+  PUBLISHER          = {YouTube},
   DATE               = {2016-12-06},
   URL                = {https://www.youtube.com/watch?v=qm1xGfOZJc8}
 }
@@ -1983,9 +1985,9 @@
 % (APA 10.13 Example 91)
 % ENTRYSUBTYPE is (obviously) not a localisation string, inserted literally
 @AUDIO{10.13:91a,
-  ENTRYSUBTYPE   = {Album recorded by Academy of St Martin in the Fields},
+  ENTRYSUBTYPE   = {Album recorded by Academy of St~Martin in the Fields},
   AUTHOR         = {J. S. Bach},
-  TITLE          = {The {B}randenburg Concertos},
+  TITLE          = {The {Brandenburg} Concertos},
   SUBTITLE       = {Concertos {BVW} 1043 \& 1060},
   PUBLISHER      = {Decca},
   DATE           = {2010},
@@ -2008,8 +2010,8 @@
   OPTIONS        = {useprefix=false},
   ENTRYSUBTYPE   = {Song recorded by Staatskapelle Dresden},
   AUTHOR         = {van Beethoven, L.},
-  TITLE          = {Symphony {N}o. 3 in {E}-flat major},
-  MAINTITLE      = {Beethoven: {C}omplete {S}ymphonies},
+  TITLE          = {Symphony {No.}~3 in {E-flat} major},
+  MAINTITLE      = {Beethoven: {Complete} {Symphonies}},
   PUBLISHER      = {Brilliant Classics},
   DATE           = {2012},
   ORIGDATE       = {1804}
@@ -2029,7 +2031,7 @@
 @AUDIO{10.13:92c,
   ENTRYSUBTYPE   = {song},
   GROUPAUTHOR    = {{Childish Gambino}},
-  TITLE          = {This is {A}merica},
+  TITLE          = {This is {America}},
   PUBLISHER      = {mcDJ and RCA},
   DATE           = {2018}
 }
@@ -2066,7 +2068,7 @@
   AUTHOR         = {I. Glass},
   AUTHOR+an:role = {1=host},
   TITLE          = {Amusement Park},
-  MAINTITLE      = {This {A}merican {L}ife},
+  MAINTITLE      = {This {American} {Life}},
   NUMBER         = {443},
   PUBLISHER      = {WBEZ Chicago},
   DATE           = {2011-08-12},
@@ -2078,7 +2080,7 @@
 @AUDIO{10.13:95,
   ENTRYSUBTYPE   = {interview},
   AUTHOR         = {de Beauvoir, S.},
-  TITLE          = {Simone de {B}eauvoir Discusses the Art of Writing},
+  TITLE          = {Simone de {Beauvoir} Discusses the Art of Writing},
   PUBLISHER      = {Studs Terkel Radio Archive and The Chicago History Museum},
   DATE           = {1960-05-04},
   URL            = {https://studsterkel.wfmt.com/programs/simone-de-beauvoir-discusses-art-writing}
@@ -2100,7 +2102,7 @@
 @IMAGE{10.14:97a,
   ENTRYSUBTYPE   = {lithograph},
   AUTHOR         = {E. Delacroix},
-  TITLE          = {Faust Attempts to Seduce {M}arguerite},
+  TITLE          = {Faust Attempts to Seduce {Marguerite}},
   LOCATION       = {The Louvre, Paris, France},
   DATE           = {1826/1827}
 }
@@ -2155,8 +2157,8 @@
 % information in brackets when there is no title
 @IMAGE{10.14:100b,
   AUTHOR         = {Google},
-  TITLEADDON     = {Google {M}aps directions for driving from {L}a {P}az,
-                    {B}olivia, to {L}ima, {P}eru},
+  TITLEADDON     = {Google {Maps} directions for driving from {La} {Paz},
+                    {Bolivia}, to {Lima}, {Peru}},
   URL            = {https://goo.gl/YYE3GR},
   URLDATE        = {2020-02-16}
 }
@@ -2195,7 +2197,7 @@
 @IMAGE{10.14:102b,
   ENTRYSUBTYPE   = {powerpoint},
   AUTHOR         = {Brian Housand},
-  TITLE          = {Game on! {I}ntegrating Games and Simulations in the Classroom},
+  TITLE          = {Game on! {Integrating} Games and Simulations in the Classroom},
   PUBLISHER      = {SlideShare},
   DATE           = {2016},
   URL            = {https://www.slideshare.net/brianhousand/game-on-iagc-2016/}
@@ -2233,7 +2235,7 @@
   GROUPAUTHOR+an:username = {1="@BadlandsNPS"},
   TITLE                   = {Biologists Have Identified More Than 400
                              Different Plant Species Growing in
-                             @{B}adlandsNPS \#{DYK} \#biodoversity},
+                             {@BadlandsNPS} \#{DYK} \#biodoversity},
   ORGANIZATION            = {Twitter},
   DATE                    = {2018-02-26},
   URL                     = {https://twitter.com/BadlandsNPS/status/968196500412133379}
@@ -2268,10 +2270,10 @@
 @ONLINE{10.15:105a,
   ENTRYSUBTYPE            = {Status update},
   AUTHOR                  = {N. Gaiman},
-  TITLE                   = {100,000+ {R}ohingya Refugees Could be at
-                             Serious Risk during {B}angladesh's Monsoon
-                             Season. {M}y Fellow {UNHCR} {G}oodwill
-                             {A}mbassador {C}ate {B}lanchett is},
+  TITLE                   = {100,000+ {Rohingya} Refugees Could be at
+                             Serious Risk during {Bangladesh's} Monsoon
+                             Season. {My} Fellow {UNHCR} {Goodwill}
+                             {Ambassador} {Cate} {Blanchett} is},
   TITLEADDON              = {Image attached},
   ORGANIZATION            = {Facebook},
   URL                     = {http://bit.ly/2JQxPAD},
@@ -2283,9 +2285,9 @@
   ENTRYSUBTYPE            = {Infographic},
   GROUPAUTHOR             = {{National Institute of Mental Health}},
   TITLE                   = {Suicide Affects all Ages, Genders, Races, and
-                             Ethnicities. {C}heck out These 5 {A}ction
-                             {S}teps for {H}elping {S}omeone in {E}motional
-                             {P}ain},
+                             Ethnicities. {Check} out These 5 {Action}
+                             {Steps} for {Helping} {Someone} in {Emotional}
+                             {Pain}},
   ORGANIZATION            = {Facebook},
   URL                     = {http://bit.ly/321Qstq},
   DATE                    = {2018-11-28}
@@ -2320,8 +2322,8 @@
   ENTRYSUBTYPE            = {photographs},
   GROUPAUTHOR             = {{Zeitz MOCAA}},
   GROUPAUTHOR+an:username = {1="@zeitzmocaa"},
-  TITLE                   = {Grade 6 Learners from {P}arkfields {P}rimary
-                             {S}chool in {H}anover {P}ark Visited the
+  TITLE                   = {Grade 6 Learners from {Parkfields} {Primary}
+                             {School} in {Hanover} {Park} Visited the
                              Museum for a Tour and Workshop Hosted by},
   ORGANIZATION            = {Instagram},
   URL                     = {https://www.instagram.com/p/BqpHpjFBs3b},
@@ -2346,9 +2348,9 @@
   ENTRYSUBTYPE            = {Online forum post},
   GROUPAUTHOR             = {{National Aeronautics Space Administration}},
   GROUPAUTHOR+an:username = {1="nasa"},
-  TITLE                   = {I'm {NASA} Astronaut {S}cott {T}ingle. {A}sk
+  TITLE                   = {I'm {NASA} Astronaut {Scott} {Tingle}. {Ask}
                              me anything about adjusting to being back on
-                             {E}arth after my first spaceflight!},
+                             {Earth} after my first spaceflight!},
   ORGANIZATION            = {Reddit},
   URL                     = {https://www.reddit.com/r/IAmA/comments/9fagqy/im_nasa_astronaut_scott_tingle_ask_me_anything/},
   DATE                    = {2018-09-12}
@@ -2357,7 +2359,7 @@
 % (APA 10.16 Example 110)
 @ONLINE{10.16:110a,
   AUTHOR             = {N. Avramova},
-  TITLE              = {The Secret to a Long, Happy, Health Life? {T}hink Age-Positive},
+  TITLE              = {The Secret to a Long, Happy, Health Life? {Think} Age-Positive},
   ORGANIZATION       = {CNN},
   DATE               = {2019-01-03},
   URL                = {https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html}
@@ -2407,14 +2409,14 @@
 
 @ONLINE{10.16:113b,
   GROUPAUTHOR   = {{National Nurses United}},
-  TITLE         = {What Employers Should do to Protect Nurses from {Z}ika},
+  TITLE         = {What Employers Should do to Protect Nurses from {Zika}},
   URL           = {https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika}
 }
 
 % (APA 10.16 Example 114)
 @ONLINE{10.16:114,
   GROUPAUTHOR   = {{U.S. Census Bureau}},
-  TITLE         = {{U}.{S}. and World Population Clock},
+  TITLE         = {{U.S.} and World Population Clock},
   ORGANIZATION  = {U.S. Department of Commerce},
   URL           = {https://www.census.gov/popclock/},
   URLDATE       = {2019-07-03}


### PR DESCRIPTION
The changes for #86 should allow to use use `@collection`, `@incollection` where appropriate in the `.bib` examples.

Also protect the entire word with braces, not only the first letter (otherwise braces can prevent kerning).


