### PR TITLE
Add missing % in apaauthor

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -500,16 +500,18 @@
        \let\bibstring\bibcplstring
        \setunit{\addspace}%
        \printtext{\mkbibparense{\usebibmacro{role}}}%
-       \hasitemannotation[\currentname][username]{\addspace\mkbibbrackets{\getitemannotation[\currentname][username]}}{}}}%
-    \ifthenelse{\value{listcount}=\value{listtotal}}%
-      {\ifmorenames
-         {\printdelim{andothersdelim}
-           \bibstring{andothers}}
-         {}%
-       \let\bibstring\bibcplstring
-       \setunit{\addspace}%
-       \printtext{\mkbibparense{\usebibmacro{roles}}}}
-      {}}
+       \hasitemannotation[\currentname][username]
+         {\addspace\mkbibbrackets{\getitemannotation[\currentname][username]}}
+         {}}}%
+  \ifthenelse{\value{listcount}=\value{listtotal}}%
+    {\ifmorenames
+       {\printdelim{andothersdelim}%
+        \bibstring{andothers}}
+       {}%
+     \let\bibstring\bibcplstring
+     \setunit{\addspace}%
+     \printtext{\mkbibparense{\usebibmacro{roles}}}}
+    {}}
 
 \DeclareNameFormat{apanames}{%
   \ifthenelse{\value{listcount}=\maxprtauth\AND\value{listcount}<\value{listtotal}}


### PR DESCRIPTION
Adds a missing `%`s in `apaauthor` and normalises the indentation.

---


The usage of `\printtext` *within* a name format can cause quite undesirable effects, so I would recommend to get rid of them. Unfortunately, that means that you can't use `\setunit` and friends either and have to check for empty contents manually.

Example of undesirable effect
```latex
\documentclass[british]{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[style=apa, backend=biber]{biblatex}

\DeclareDelimFormat*{multinamedelim}{\slash} 
\DeclareDelimFormat*{finalnamedelim}{} 
\DeclareDelimAlias{finalnamedelim}{multinamedelim} 
\DeclareDelimFormat*{finalnamedelim:apa:family-given}{}
\DeclareDelimAlias{finalnamedelim:apa:family-given}{multinamedelim}

\addbibresource{biblatex-examples.bib}

\begin{document}
\cite{sigfridsson}
\printbibliography
\end{document}
```