### PR TITLE
Remove \printtext and \setunit from name/field formats

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -516,12 +516,12 @@
     {\addcomma\space\ldots\space}
     {\ifthenelse{\value{listcount}>\maxprtauth\AND\value{listcount}<\value{listtotal}}
       {}
-      {\printtext{\usebibmacro{name:apa:given-family}%
+      {\usebibmacro{name:apa:given-family}%
          {\namepartfamily}%
          {\namepartgiven}%
          {\namepartgiveni}%
          {\namepartprefix}%
-         {\namepartsuffix}}%       
+         {\namepartsuffix}%       
        \let\bibstring\bibcpsstring
        \usebibmacro{role}{\addcomma\space}{\@firstofone}}}%
   \ifthenelse{\value{listcount}=\value{listtotal}}%
@@ -583,9 +583,12 @@
   \printfield{nameaddon}%
   \ifnameundef{with}
     {}
-    {\setunit{}\addspace\mkbibparens{\printtext{\bibstring{with}\addspace}%
-     \printnames[apaauthor][-\value{listtotal}]{with}}
-     \setunit*{\addspace}}}
+    {\setunit{\addspace}%
+     \printtext[parens]{%
+       \bibstring{with}%
+       \setunit{\addspace}%
+       \printnames[apaauthor][-\value{listtotal}]{with}}%
+     \setunit{\addspace}}}
 
 \newbibmacro*{author:related}{%
   \ifnameundef{author}
@@ -637,8 +640,8 @@
 
 \DeclareFieldFormat{apadate}{%
   \ifboolexpr{ test {\ifdatecirca} or test {\ifdateuncertain} }
-    {\printtext{\mkbibbrackets{#1}}}
-    {\printtext{\mkbibparens{#1}}}}
+    {\mkbibbrackets{#1}}
+    {\mkbibparens{#1}}}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -756,9 +759,10 @@
 \renewbibmacro*{eprint}{%
   \iffieldundef{eprinttype}
     {}
-    {\printtext{%
-       \iffieldbibstring{eprinttype}{\bibcplstring{\strfield{eprinttype}}}{\strfield{eprinttype}}%
-       \setunit{\addspace}}}%
+    {\iffieldbibstring{eprinttype}
+       {\bibcplstring{\strfield{eprinttype}}}
+       {\strfield{eprinttype}}%
+     \setunit{\addspace}}%
   \printfield{eprint}}
 
 \DeclareFieldFormat{eprint}{#1}
@@ -973,7 +977,7 @@
         \setunit*{\addcomma\addspace}%
         \usebibmacro{apaeditorstrg}{editor}%
         \setunit*{\addspace\&\space}%
-        \printtext{\bibcpstring{translator}}}
+        \bibcpstring{translator}}
        {\ifnameundef{editor}%
           {}%
           {\printnames[apanames][-\value{listtotal}]{editor}%
@@ -985,13 +989,13 @@
           {\setunit{}}%
           {\printnames[apanames][-\value{listtotal}]{translator}%
            \setunit{\addcomma\addspace}%
-           \printtext{\bibcpstring{translator}}%
+           \bibcpstring{translator}%
            \clearname{translator}}%
         \ifnameundef{narrator}%
           {\setunit{}}%
           {\printnames[apanames][-\value{listtotal}]{narrator}%
            \setunit{\addcomma\addspace}%
-           \printtext{\bibcpstring{narrator}}%
+           \bibcpstring{narrator}%
            \clearname{narrator}}}}}
 
 \newbibmacro*{editor+trans}{%
@@ -1059,7 +1063,10 @@
     not test {\iffieldundef{origyear}}
     not test {\iffieldundef{labelyear}}
     and not test {\iffieldsequal{labelyear}{origyear}}}
-    {\printtext{\mkbibparens{\bibcpstring{origyear}~\printorigdate}}%
+    {\printtext[parens]{%
+       \bibcpstring{origyear}
+       \setunit{\addnbspace}%
+       \printorigdate}%
      \renewcommand*{\finentrypunct}{\relax}}
     {}}
 
@@ -1220,11 +1227,12 @@
 % (APA 10.12) Audiovisual
 
 \newbibmacro*{mainvideo}{%
-  \iffieldundef{maintitle}{}
+  \iffieldundef{maintitle}
+    {}
     {\usebibmacro{in}%
      \printnames[apanames][-\value{listtotal}]{execproducer}%
      \setunit{\addspace}%
-     \printtext{\mkbibparens{\bibcplstring{execproducers}}}%
+     \bibcplstring[\mkbibparens]{execproducers}%
      \setunit{\addcomma\addspace}%
      \printfield{maintitle}}}
 
@@ -1355,9 +1363,9 @@
   % disable normal date printing if it's in the citation info
   \iftoggle{apa:courtdate}
     {\iflistundef{organization}
-      {\printtext{\mkbibparens{#1}}}
-      {\printtext{\mkbibparens{%
-          \printlist{organization}\space #1}}}}
+      {\mkbibparens{#1}}
+      {\mkbibparens{%
+         \printlist{organization}\space #1}}}
     {}}
 
 % 
@@ -2052,8 +2060,8 @@
     {}
     {\iffieldundef{urlyear}
       {}
-      {\printtext{\bibstring{retrieved}}%
-       \addspace
+      {\bibstring{retrieved}%
+       \setunit{\addspace}%
        \printurldate
        \setunit{\urldatecomma}%
        \bibstring{from}%

--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -491,15 +491,14 @@
     {\addcomma\space\ldots\space}
     {\ifthenelse{\value{listcount}>\maxprtauth\AND\value{listcount}<\value{listtotal}}
       {}
-      {\printtext{\usebibmacro{name:apa:family-given}%
+      {\usebibmacro{name:apa:family-given}%
          {\namepartfamily}%
          {\namepartgiven}%
          {\namepartgiveni}%
          {\namepartprefix}%
-         {\namepartsuffix}}%
+         {\namepartsuffix}%
        \let\bibstring\bibcplstring
-       \setunit{\addspace}%
-       \printtext{\mkbibparense{\usebibmacro{role}}}%
+       \usebibmacro{role}{\addspace}{\mkbibparens}%
        \hasitemannotation[\currentname][username]
          {\addspace\mkbibbrackets{\getitemannotation[\currentname][username]}}
          {}}}%
@@ -509,8 +508,7 @@
         \bibstring{andothers}}
        {}%
      \let\bibstring\bibcplstring
-     \setunit{\addspace}%
-     \printtext{\mkbibparense{\usebibmacro{roles}}}}
+     \usebibmacro{roles}{\addspace}{\mkbibparens}}
     {}}
 
 \DeclareNameFormat{apanames}{%
@@ -525,16 +523,14 @@
          {\namepartprefix}%
          {\namepartsuffix}}%       
        \let\bibstring\bibcpsstring
-       \setunit{\addcomma\addspace}%
-       \usebibmacro{role}}}%
+       \usebibmacro{role}{\addcomma\space}{\@firstofone}}}%
   \ifthenelse{\value{listcount}=\value{listtotal}}%
     {\ifmorenames
        {\printdelim{andothersdelim}%
         \bibstring{andothers}}
        {}%
      \let\bibstring\bibcplstring
-     \setunit{\addspace}%
-     \usebibmacro{roles}}
+     \usebibmacro{roles}{\addspace}{\@firstofone}}
     {}}
 
 \renewbibmacro*{author/editor}{%
@@ -813,73 +809,79 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Names
 
+\newcommand*{\apabbx@ifrole@item}{%
+  \xifinlist{item@\currentname @role@\the\value{listcount}}%
+            \abx@annotation@defined}
+
+\newtoggle{apabbx:role:item:punct}
+
+\newcommand*{\apabbx@rolelist@item}{}
+\forcsvlist{\listadd\apabbx@rolelist@item}{%
+  writer,director,execproducer,producer,host,chair,guestexpert}
+
+\newcommand*{\apabbx@printrole@item@i}[1]{%
+  \ifitemannotation[\currentname][role]{#1}
+    {\iftoggle{apabbx:role:item:punct}
+       {\addspace\&\space}
+       {}%
+     \bibstring{#1}%
+     \toggletrue{apabbx:role:item:punct}}
+    {}%
+}
+
+\newcommand*{\apabbx@printrole@item}{%
+  \forlistloop{\apabbx@printrole@item@i}{\apabbx@rolelist@item}}
+
 % Individual name roles
-\newbibmacro*{role}{%
-  \hasitemannotation[\currentname][role]%
-    {\getitemannotation[\currentname][role]}
-    {\ifitemannotation[\currentname][role]{writer}
-       {\bibstring{writer}%
-        \setunit{\addspace\&\addspace}}
+% takes two arguments
+% {<pre punct>}{<wrapper>}
+\newbibmacro*{role}[2]{%
+  \apabbx@ifrole@item
+    {#1%
+     #2{%
+       \togglefalse{apabbx:role:item:punct}%
+       \hasitemannotation[\currentname][role]%
+         {\getitemannotation[\currentname][role]}
+         {\apabbx@printrole@item}}}
+    {}%
+}
+
+\newcommand*{\apabbx@ifrole@field}{%
+  \xifinlist{field@\currentname @role@}%
+            \abx@annotation@defined}
+            
+\newtoggle{apabbx:role:field:punct}
+
+\newcommand*{\apabbx@rolelist@field}{}
+\forcsvlist{\listadd\apabbx@rolelist@field}{%
+  writers,directors,execproducers,producers,hosts,chairs,guestexperts}
+
+\newcommand*{\apabbx@printrole@field@i}[1]{%
+  \iffieldannotation[\currentname][role]{#1}
+    {\iftoggle{apabbx:role:field:punct}
+       {\addspace\&\space}
        {}%
-     \ifitemannotation[\currentname][role]{director}
-       {\bibstring{director}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \ifitemannotation[\currentname][role]{execproducer}
-       {\bibstring{execproducer}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \ifitemannotation[\currentname][role]{producer}
-       {\bibstring{producer}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \ifitemannotation[\currentname][role]{host}
-       {\bibstring{host}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \ifitemannotation[\currentname][role]{chair}
-       {\bibstring{chair}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \ifitemannotation[\currentname][role]{guestexpert}
-       {\bibstring{guestexpert}%
-         \setunit{\addspace\&\addspace}}
-       {}}%
-  \setunit{}}
+     \bibstring{#1}%
+     \toggletrue{apabbx:role:field:punct}}
+    {}%
+}
+
+\newcommand*{\apabbx@printrole@field}{%
+  \forlistloop{\apabbx@printrole@field@i}{\apabbx@rolelist@field}}
 
 % roles for complete name lists
-\newbibmacro*{roles}{%
-  \hasfieldannotation[\currentname][role]%
-    {\getfieldannotation[\currentname][role]}
-    {\iffieldannotation[\currentname][role]{writers}
-       {\bibstring{writers}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \iffieldannotation[\currentname][role]{directors}
-       {\bibstring{directors}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \iffieldannotation[\currentname][role]{execproducers}
-       {\bibstring{execproducers}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \iffieldannotation[\currentname][role]{producers}
-       {\bibstring{producers}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \iffieldannotation[\currentname][role]{hosts}
-       {\bibstring{hosts}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \iffieldannotation[\currentname][role]{chairs}
-       {\bibstring{chairs}%
-         \setunit{\addspace\&\addspace}}
-       {}%
-     \iffieldannotation[\currentname][role]{guestexperts}
-       {\bibstring{guestexperts}%
-         \setunit{\addspace\&\addspace}}
-       {}}%
-  \setunit{}}
+% takes two arguments
+% {<pre punct>}{<wrapper>}
+\newbibmacro*{roles}[2]{%
+  \apabbx@ifrole@field
+    {#1%
+     #2{%
+       \togglefalse{apabbx:role:field:punct}%
+       \hasfieldannotation[\currentname][role]%
+         {\getfieldannotation[\currentname][role]}
+         {\apabbx@printrole@field}}}
+    {}%
+}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
As commented in #88 the `\printtext`s and `\setunit`s in name/field formats could cause problems because the punctuation tracker does not operate very well in nested situations.

This also removes a spurious space in
```latex
\documentclass[british]{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[style=apa, backend=biber]{biblatex}

\addbibresource{biblatex-apa-test-references.bib}

\begin{document}
\cite{9.8:9}
\printbibliography
\end{document}
```

> Meyers, K. (with Long, W. T. ). (2014). Withering worrying.