### PR TITLE
Make URLstyle same

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -15,7 +15,7 @@
 \ProvidesFile{apa.bbx}[2020/04/26\space v9.10\space APA biblatex references style]
 \RequireBiber[3]
 \RequireBibliographyStyle{standard}
-\urlstyle{rm} % APA examples all have URLs in same font as text
+\urlstyle{same} % APA examples all have URLs in same font as text
 
 % Declare the language mapping suffix
 \DeclareLanguageMappingSuffix{-apa}


### PR DESCRIPTION
`\urlstyle{same}` also obeys rm/sf changes

Compare
```latex
\documentclass[american]{article}
\usepackage[T1]{fontenc}
\usepackage{lmodern}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[style=apa, backend=biber]{biblatex}

\renewcommand*\familydefault{\sfdefault}

\addbibresource{biblatex-examples.bib}


\begin{document}
\cite{sigfridsson,ctan,markey}
\printbibliography
\end{document}
```
with `\urlstyle{rm}` and `\urlstyle{same}`.