### PR TITLE
Rework \textcite and \nptextcite

### DIFF
--- a/tex/latex/biblatex-apa/cbx/apa.cbx
+++ b/tex/latex/biblatex-apa/cbx/apa.cbx
@@ -258,6 +258,10 @@
            {}
            {\printnames{shortauthor}%
             \setunit{\printdelim{nameyeardelim}}}}%
+  % Print prenote (belongs to first cite)
+        \ifnumequal{\value{citecount}}{1}
+           {\usebibmacro{prenote}}
+           {}%
   % Actual year printing
         \usebibmacro{cite:plabelyear+extradate}%
   % Save name hash for checks later
@@ -552,7 +556,6 @@
 
 \DeclareCiteCommand{\cbx@textcite}
   {\usebibmacro{cite:init}%
-   \usebibmacro{prenote}%
    \toggletrue{apa:intcite}}
   {\usebibmacro{citeindex}%
    \usebibmacro{textcite}%

--- a/tex/latex/biblatex-apa/cbx/apa.cbx
+++ b/tex/latex/biblatex-apa/cbx/apa.cbx
@@ -9,7 +9,7 @@
 %% version 2005/12/01 or later.
 %%
 %% This work has the LPPL maintenance status `maintained'.
-%% 
+%%
 %% The Current Maintainer of this work is Philip Kime.
 
 \ProvidesFile{apa.cbx}[2020/04/26\space v9.10\space APA biblatex citation style]
@@ -43,79 +43,11 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
-% (APA 8.17) ampersand separator in parenthetical cites
-
-\newtoggle{apa:inpcite}
-
-\DeclareDelimFormat[parencite]{finalnamedelim}
-  {\ifnum\value{liststop}>2 \finalandcomma\fi\addspace\&\space}
-
-\DeclareCiteCommand{\parencite}[\mkbibparens]
-  {\usebibmacro{cite:init}%
-   \usebibmacro{prenote}%
-   \toggletrue{apa:inpcite}}
-  {\usebibmacro{citeindex}%
-   \usebibmacro{cite}%
-   \usebibmacro{cite:post}}
-  {}
-  {\usebibmacro{postnote}%
-   \togglefalse{apa:inpcite}}
-
-\DeclareCiteCommand*{\parencite}[\mkbibparens]
-  {\usebibmacro{cite:init}%
-   \usebibmacro{prenote}%
-   \toggletrue{apa:inpcite}}
-  {\usebibmacro{citeindex}%
-   \usebibmacro{citeyear}%
-   \usebibmacro{cite:post}%
-   \togglefalse{apa:inpcite}}
-  {}
-  {\usebibmacro{postnote}}
-
-%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% (APA 8.11) No parens round year for cites when the cite is in
-%            parentheses. Use new command \nptextcite for such cites.
-
-\DeclareDelimFormat[nptextcite]{finalnamedelim}
-  {\ifnum\value{liststop}>2 \finalandcomma\fi\addspace\&\space}
-
-\DeclareCiteCommand{\nptextcite}
-  {\usebibmacro{cite:init}%
-   \usebibmacro{prenote}%
-   \toggletrue{apa:inpcite}}
-  {\usebibmacro{citeindex}%
-   \usebibmacro{cite}%
-   \usebibmacro{cite:post}}
-  {}
-  {\usebibmacro{postnote}%
-   \togglefalse{apa:inpcite}}
-
-\DeclareMultiCiteCommand{\nptextcites}{\nptextcite}
-  {\setunit{\multicitedelim}}
-
-\DeclareCiteCommand*{\nptextcite}
-  {\usebibmacro{cite:init}%
-   \usebibmacro{prenote}%
-   \toggletrue{apa:inpcite}}
-  {\usebibmacro{citeindex}%
-   \usebibmacro{citeyear}%
-   \usebibmacro{cite:post}%
-   \togglefalse{apa:inpcite}}
-  {}
-  {\usebibmacro{postnote}}
-
-%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % (APA 8.10) Suffices are not shown in citations
 % (APA 8.17) 3+ authors have "et al."
 % (APA 8.20) Initials only for primary author and only when not unique across all *primary* authors
-  
+
 \newbibmacro*{labelname:doname}[8]{%
   \ifboolexpr{test {\ifnumcomp{\value{listcount}}{>}{1}}
               or
@@ -218,7 +150,7 @@
 % X and Y and Z (2009)
 % X and W and V (2010)
 %
-% which have the same namehash due to minnames visibility truncation to 1 
+% which have the same namehash due to minnames visibility truncation to 1
 % would be printed incorrectly as
 % \cite{one, two} -> X, Y & Z 2009, 2010
 \newbibmacro*{cite}{%
@@ -409,7 +341,7 @@
        {\biblclstring{repealed}\setunit{\addspace}\printeventdate}
        {}}
     {}}
-       
+
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -424,13 +356,13 @@
     {\ifcurrentfield{shorthand}
       {\mkbibemph{#1}}
       {#1}}}
-  
+
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % No shorthand
-% 
+%
 \newbibmacro*{citeyear}{%
   \iffieldundef{labelyear}
     {\usebibmacro{cite:init}}
@@ -510,6 +442,15 @@
     {\printfield{labelyear}%
        \printfield{extradate}}}
 
+\DeclareCiteCommand{\citeauthor}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{cite:author}%
+   \usebibmacro{cite:post}}
+  {}
+  {\usebibmacro{postnote}}
+
 \DeclareCiteCommand{\citeyear}
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
@@ -527,6 +468,8 @@
   {}
   {\usebibmacro{postnote}}
 
+\DeclareMultiCiteCommand{\cites}{\cite}{\setunit{\multicitedelim}}
+
 \DeclareCiteCommand*{\cite}
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
@@ -536,9 +479,79 @@
   {}
   {\usebibmacro{postnote}}
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% (APA 8.17) ampersand separator in parenthetical cites
+
+\newtoggle{apa:inpcite}
+
+\DeclareDelimFormat[parencite]{finalnamedelim}
+  {\ifnum\value{liststop}>2 \finalandcomma\fi\addspace\&\space}
+
+\DeclareCiteCommand{\parencite}[\mkbibparens]
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}%
+   \toggletrue{apa:inpcite}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{cite}%
+   \usebibmacro{cite:post}}
+  {}
+  {\usebibmacro{postnote}%
+   \togglefalse{apa:inpcite}}
+
+\DeclareMultiCiteCommand{\parencites}[\mkbibparens]{\parencite}
+  {\setunit{\multicitedelim}}
+
+\DeclareCiteCommand*{\parencite}[\mkbibparens]
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}%
+   \toggletrue{apa:inpcite}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{citeyear}%
+   \usebibmacro{cite:post}%
+   \togglefalse{apa:inpcite}}
+  {}
+  {\usebibmacro{postnote}}
+
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% (APA 8.11) No parens round year for cites when the cite is in
+%            parentheses. Use new command \nptextcite for such cites.
+
+\DeclareDelimFormat[nptextcite]{finalnamedelim}
+  {\ifnum\value{liststop}>2 \finalandcomma\fi\addspace\&\space}
+
+\DeclareCiteCommand{\nptextcite}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}%
+   \toggletrue{apa:inpcite}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{cite}%
+   \usebibmacro{cite:post}}
+  {}
+  {\usebibmacro{postnote}%
+   \togglefalse{apa:inpcite}}
+
+\DeclareMultiCiteCommand{\nptextcites}{\nptextcite}
+  {\setunit{\multicitedelim}}
+
+\DeclareCiteCommand*{\nptextcite}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}%
+   \toggletrue{apa:inpcite}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{citeyear}%
+   \usebibmacro{cite:post}%
+   \togglefalse{apa:inpcite}}
+  {}
+  {\usebibmacro{postnote}}
+
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \DeclareCiteCommand{\footcite}[\mkbibfootnote]
-  {\bibsentence
-   \usebibmacro{cite:init}%
+  {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}%
@@ -546,13 +559,29 @@
   {}
   {\usebibmacro{postnote}}
 
-\DeclareMultiCiteCommand{\cites}{\cite}{\setunit{\multicitedelim}}
-\DeclareMultiCiteCommand{\parencites}[\mkbibparens]{\parencite}
-  {\setunit{\multicitedelim}}
 \DeclareMultiCiteCommand{\footcites}[\mkbibfootnote]{\footcite}
   {\setunit{\multicitedelim}}
+
+\DeclareCiteCommand{\footcitetext}[\mkbibfootnotetext]
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{cite}%
+   \usebibmacro{cite:post}}
+  {}
+  {\usebibmacro{postnote}}
+
 \DeclareMultiCiteCommand{\footcitetexts}[\mkbibfootnotetext]
   {\footcitetext}{\setunit{\multicitedelim}}
+
+\DeclareCiteCommand{\smartcite}[\iffootnote\mkbibparens\mkbibfootnote]
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{cite}}
+  {}
+  {\usebibmacro{postnote}}
+
 \DeclareMultiCiteCommand{\smartcites}[\iffootnote\mkbibparens\mkbibfootnote]
 {\smartcite}{\setunit{\multicitedelim}}
 
@@ -601,14 +630,5 @@
 
 \let\cbx@textcites@init\cbx@textcite@init
 \pretocmd{\cbx@textcites@init}{\UseNextMultiCiteHook}{}{}
-
-\DeclareCiteCommand{\citeauthor}
-  {\usebibmacro{cite:init}%
-   \usebibmacro{prenote}}
-  {\usebibmacro{citeindex}%
-   \usebibmacro{cite:author}%
-   \usebibmacro{cite:post}}
-  {}
-  {\usebibmacro{postnote}}
 
 \endinput

--- a/tex/latex/biblatex-apa/cbx/apa.cbx
+++ b/tex/latex/biblatex-apa/cbx/apa.cbx
@@ -76,6 +76,41 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% (APA 8.11) No parens round year for cites when the cite is in
+%            parentheses. Use new command \nptextcite for such cites.
+
+\DeclareDelimFormat[nptextcite]{finalnamedelim}
+  {\ifnum\value{liststop}>2 \finalandcomma\fi\addspace\&\space}
+
+\DeclareCiteCommand{\nptextcite}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}%
+   \toggletrue{apa:inpcite}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{cite}%
+   \usebibmacro{cite:post}}
+  {}
+  {\usebibmacro{postnote}%
+   \togglefalse{apa:inpcite}}
+
+\DeclareMultiCiteCommand{\nptextcites}{\nptextcite}
+  {\setunit{\multicitedelim}}
+
+\DeclareCiteCommand*{\nptextcite}
+  {\usebibmacro{cite:init}%
+   \usebibmacro{prenote}%
+   \toggletrue{apa:inpcite}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{citeyear}%
+   \usebibmacro{cite:post}%
+   \togglefalse{apa:inpcite}}
+  {}
+  {\usebibmacro{postnote}}
+
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % (APA 8.10) Suffices are not shown in citations
 % (APA 8.17) 3+ authors have "et al."
@@ -230,9 +265,7 @@
        {\iffieldundef{shorthand}%
     % Cite using title
          {\usebibmacro{cite:noname}%
-          \setunit{\ifbool{cbx:np}%
-                   {\printdelim{nameyeardelim}}%
-                   {\global\booltrue{cbx:parens}\addspace\bibopenparen}}%
+          \setunit{\global\booltrue{cbx:parens}\addspace\bibopenparen}%
           \usebibmacro{cite:plabelyear+extradate}}
     % Cite using shorthand
          {\usebibmacro{cite:shorthand}}}
@@ -248,9 +281,7 @@
              {\printnames[labelname]{author}}
              {\printnames[labelname]{groupauthor}}}}%
   % Year
-        \setunit{\ifbool{cbx:np}
-                  {\printdelim{nameyeardelim}}
-                  {\global\booltrue{cbx:parens}\addspace\bibopenparen}}%
+        \setunit{\global\booltrue{cbx:parens}\addspace\bibopenparen}%
   % Put the shortauthor inside the year brackets if necessary
         \ifnameundef{shortauthor}
          {}
@@ -396,32 +427,6 @@
   
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% (APA 8.11) No parens round year for cites when the cite is in
-%            parentheses. Use new command \nptextcite for such cites.
-
-\DeclareDelimFormat[nptextcite]{finalnamedelim}
-  {\ifnum\value{liststop}>2 \finalandcomma\fi\addspace\&\space}
-
-\DeclareMultiCiteCommand{\nptextcites}{\nptextcite}{\setunit{\multicitedelim}}
-
-\DeclareCiteCommand{\nptextcite}
-  {\usebibmacro{cite:init}%
-   \usebibmacro{prenote}}
-  {\usebibmacro{citeindex}%
-   \global\booltrue{cbx:np}%
-   \usebibmacro{textcite}%
-   \usebibmacro{cite:post}%
-   \global\boolfalse{cbx:np}}%
-  {}
-  {\iffieldundef{postnote}
-     {}
-     {\printdelim{nameyeardelim}%
-      \printfield{postnote}}}
-
-%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % No shorthand
@@ -477,7 +482,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \newbool{cbx:parens} % boolean to say we're inside parens
-\newbool{cbx:np} % boolean to say we're using a non-parentheses text cite
 
 \newbibmacro*{textcite:postnote}{%
   \usebibmacro{postnote}%

--- a/tex/latex/biblatex-apa/cbx/apa.cbx
+++ b/tex/latex/biblatex-apa/cbx/apa.cbx
@@ -212,19 +212,21 @@
       \savefield{fullhash}{\cbx@lasthash}}}%
    \setunit{\multicitedelim}}
 
+\renewcommand*{\iffinalcitedelim}{%
+  \ifnumequal{\value{textcitecount}}{\value{textcitetotal}-1}}
+
 \newbibmacro*{textcite}{%
   \iffieldequals{fullhash}{\cbx@lasthash}
 % Compact cite - more than one thing for same author
     {\setunit{\compcitedelim}%
      \usebibmacro{cite:plabelyear+extradate}}
 % New cite
-    {%
-    \ifbool{cbx:parens}
-      {\bibcloseparen\global\boolfalse{cbx:parens}}
-      {}%
-      \setunit{\compcitedelim}%
-      \ifnameundef{labelname}
-  % No author/editor
+    {\ifbool{cbx:parens}
+       {\bibcloseparen\global\boolfalse{cbx:parens}}
+       {}%
+     \setunit{\textcitedelim}%
+     \ifnameundef{labelname}
+     % No author/editor
        {\iffieldundef{shorthand}%
     % Cite using title
          {\usebibmacro{cite:noname}%
@@ -254,11 +256,13 @@
          {}
          {\cbx@apa@ifnamesaved
            {}
-           {\printnames{shortauthor}\setunit{\printdelim{nameyeardelim}}}}%
+           {\printnames{shortauthor}%
+            \setunit{\printdelim{nameyeardelim}}}}%
   % Actual year printing
         \usebibmacro{cite:plabelyear+extradate}%
   % Save name hash for checks later
-        \savefield{fullhash}{\cbx@lasthash}}}}
+        \savefield{fullhash}{\cbx@lasthash}}%
+    \stepcounter{textcitecount}}}
 
 \newbibmacro*{cite:plabelyear+extradate}{%
   \iffieldundef{labelyear}{}
@@ -534,7 +538,6 @@
   {}
   {\usebibmacro{postnote}}
 
-\DeclareMultiCiteCommand{\textcites}{\textcite}{\setunit{\compcitedelim}}
 \DeclareMultiCiteCommand{\cites}{\cite}{\setunit{\multicitedelim}}
 \DeclareMultiCiteCommand{\parencites}[\mkbibparens]{\parencite}
   {\setunit{\multicitedelim}}
@@ -547,7 +550,7 @@
 
 \newtoggle{apa:intcite}
 
-\DeclareCiteCommand{\textcite}
+\DeclareCiteCommand{\cbx@textcite}
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}%
    \toggletrue{apa:intcite}}
@@ -557,6 +560,40 @@
    \togglefalse{apa:intcite}}
   {}
   {\usebibmacro{textcite:postnote}}
+
+\DeclareCiteCommand{\textcite}[\cbx@textcite@init\cbx@textcite]
+  {\gdef\cbx@savedkeys{}%
+   \citetrackerfalse%
+   \pagetrackerfalse%
+   \DeferNextCitekeyHook%
+   \usebibmacro{cite:init}}
+  {\ifthenelse{\iffirstcitekey\AND\value{multicitetotal}>0}
+     {\protected@xappto\cbx@savedcites{()(\thefield{multipostnote})}%
+      \global\clearfield{multipostnote}}
+     {}%
+   \xappto\cbx@savedkeys{\thefield{entrykey},}%
+   \iffieldequals{namehash}{\cbx@lasthash}
+     {}
+     {\stepcounter{textcitetotal}%
+      \savefield{namehash}{\cbx@lasthash}}}
+  {}
+  {\protected@xappto\cbx@savedcites{%
+     [\thefield{prenote}][\thefield{postnote}]{\cbx@savedkeys}}}
+
+% textcite has nested \DeclareCiteCommand definitions for textcite and we want to use
+% the normal textcite context
+\DeclareDelimcontextAlias{cbx@textcite}{textcite}
+
+\newrobustcmd{\cbx@textcite@init}[2]{%
+  \setcounter{textcitetotal}{0}%
+  \setcounter{textcitecount}{0}%
+  \def\cbx@savedcites{#1}#2\cbx@savedcites\empty}
+
+\DeclareMultiCiteCommand{\cbx@textcites}{\cbx@textcite}{}
+\DeclareMultiCiteCommand{\textcites}[\cbx@textcites@init\cbx@textcites]{\textcite}{}
+
+\let\cbx@textcites@init\cbx@textcite@init
+\pretocmd{\cbx@textcites@init}{\UseNextMultiCiteHook}{}{}
 
 \DeclareCiteCommand{\citeauthor}
   {\usebibmacro{cite:init}%


### PR DESCRIPTION
As discussed in #94. See also #78, #90.

* Base `\textcite` in `authoryear-comp`'s two-pass `\textcite`.
* Base `\nptextcite` on `\parencite` (the name doesn't quite fit any more, but it's probably not a good idea to change it now).