### PR TITLE
Use eid for eLocator/article number (#107)

### DIFF
--- a/bibtex/bib/biblatex-apa-test-references.bib
+++ b/bibtex/bib/biblatex-apa-test-references.bib
@@ -592,8 +592,7 @@
   VOLUME         = {14},
   NUMBER         = {1},
   DATE           = {2019},
-  EPRINTTYPE     = {article},
-  EPRINT         = {e0209899},
+  EID            = {e0209899},
   DOI            = {10.1371/journal.pone.0209899}
 }
 

--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -779,18 +779,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % (APA 10.1 Example 6) eprints (eLocator)
 
-\renewbibmacro*{eprint}{%
-  \iftoggle{bbx:eprint}
-    {\iffieldundef{eprinttype}
-       {}
-       {\iffieldbibstring{eprinttype}
-          {\bibcplstring{\strfield{eprinttype}}}
-          {\strfield{eprinttype}}%
-        \setunit{\addspace}}%
-     \printfield{eprint}}
-    {}}
-
-\DeclareFieldFormat{eprint}{#1}
+\DeclareFieldFormat[article]{eid}{\bibcpstring{jourarticle}~#1}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -804,8 +793,8 @@
   \setunit*{\addcomma\addspace}%
   \printfield{volume}%
   \printfield{number}%
-  \setunit*{\addcomma\addspace}%
-  \usebibmacro{eprint}%
+  \setunit{\addcomma\addspace}%
+  \printfield{eid}%
   \newunit\newblock
   \usebibmacro{issuename}%
   \newunit}

--- a/tex/latex/biblatex-apa/lbx/american-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/american-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{american-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{american}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}
@@ -127,6 +128,7 @@
 
 \DeclareBibliographyStrings{%
   inherit          = {american},
+  jourarticle      = {{article}{article}},
   ofthe            = {{of\space the}{of\space the}},
   tothe            = {{to\space the}{to\space the}},
   unitednations    = {{United\space Nations}{U\adddot N\adddot}},

--- a/tex/latex/biblatex-apa/lbx/austrian-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/austrian-apa.lbx
@@ -4,6 +4,7 @@
 % Following DGPs guidlines for German/Austrian
 % http://homepage.univie.ac.at/harald.werneck/Richtlinien_zur_Manuskriptgestaltung.pdf
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}
@@ -68,6 +69,7 @@
   
 \DeclareBibliographyStrings{%
   inherit          = {austrian},
+  jourarticle      = {{Artikel}{Artikel}},
   tothe            = {{to\space the}{to\space the}},%FIXME
   ofthe            = {{of\space the}{of\space the}},%FIXME
   unitednations    = {{United\space Nations}{U\adddot N\adddot}},

--- a/tex/latex/biblatex-apa/lbx/brazilian-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/brazilian-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{brazilian-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{brazilian}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/british-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/british-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{british-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{british}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}
@@ -65,6 +66,7 @@
 
 \DeclareBibliographyStrings{%
   inherit          = {british},
+  jourarticle      = {{article}{article}},
   tothe            = {{to\space the}{to\space the}},
   ofthe            = {{of\space the}{of\space the}},
   unitednations    = {{United\space Nations}{U\adddot N\adddot}},

--- a/tex/latex/biblatex-apa/lbx/danish-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/danish-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{danish-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{danish}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/dutch-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/dutch-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{dutch-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{dutch}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/english-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/english-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{english-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{english}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}
@@ -65,6 +66,7 @@
 
 \DeclareBibliographyStrings{%
   inherit          = {american},
+  jourarticle      = {{article}{article}},
   tothe            = {{to\space the}{to\space the}},
   ofthe            = {{of\space the}{of\space the}},
   unitednations    = {{United\space Nations}{U\adddot N\adddot}},

--- a/tex/latex/biblatex-apa/lbx/french-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/french-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{french-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{french}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/galician-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/galician-apa.lbx
@@ -3,6 +3,7 @@
 
 \setcounter{smartand}{0} % Turn off "smart and" or ampersands will all be replaced
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/german-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/german-apa.lbx
@@ -4,6 +4,7 @@
 % Following DGPs guidlines for German/Austrian
 % http://homepage.univie.ac.at/harald.werneck/Richtlinien_zur_Manuskriptgestaltung.pdf
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}
@@ -68,6 +69,7 @@
 
 \DeclareBibliographyStrings{%
   inherit          = {german},
+  jourarticle      = {{Artikel}{Artikel}},
   tothe            = {{to\space the}{to\space the}},%FIXME
   ofthe            = {{of\space the}{of\space the}},%FIXME
   unitednations    = {{United\space Nations}{U\adddot N\adddot}},

--- a/tex/latex/biblatex-apa/lbx/greek-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/greek-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{greek-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{greek}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/italian-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/italian-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{italian-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{italian}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/naustrian-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/naustrian-apa.lbx
@@ -4,6 +4,7 @@
 % Following DGPs guidlines for German/Austrian
 % http://homepage.univie.ac.at/harald.werneck/Richtlinien_zur_Manuskriptgestaltung.pdf
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}
@@ -68,6 +69,7 @@
 
 \DeclareBibliographyStrings{%
   inherit          = {naustrian},
+  jourarticle      = {{Artikel}{Artikel}},
   tothe            = {{to\space the}{to\space the}},%FIXME
   ofthe            = {{of\space the}{of\space the}},%FIXME
   unitednations    = {{United\space Nations}{U\adddot N\adddot}},

--- a/tex/latex/biblatex-apa/lbx/ngerman-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/ngerman-apa.lbx
@@ -4,6 +4,7 @@
 % Following DGPs guidlines for German/Austrian
 % http://homepage.univie.ac.at/harald.werneck/Richtlinien_zur_Manuskriptgestaltung.pdf
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}
@@ -68,6 +69,7 @@
 
 \DeclareBibliographyStrings{%
   inherit          = {ngerman},
+  jourarticle      = {{Artikel}{Artikel}},
   tothe            = {{to\space the}{to\space the}},%FIXME
   ofthe            = {{of\space the}{of\space the}},%FIXME
   unitednations    = {{United\space Nations}{U\adddot N\adddot}},

--- a/tex/latex/biblatex-apa/lbx/nynorsk-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/nynorsk-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{nynorsk-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{nynorsk}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/portuguese-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/portuguese-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{portuguese-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{portuguese}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/russian-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/russian-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{russian-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{russian}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/slovene-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/slovene-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{slovene-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{slovene}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/spanish-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/spanish-apa.lbx
@@ -3,6 +3,7 @@
 
 \setcounter{smartand}{0} % Turn off "smart and" or ampersands will all be replaced
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/swedish-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/swedish-apa.lbx
@@ -1,6 +1,7 @@
 \ProvidesFile{swedish-apa.lbx}[2020/04/26\space v9.10\space APA biblatex localisation]
 \InheritBibliographyExtras{swedish}
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}

--- a/tex/latex/biblatex-apa/lbx/swissgerman-apa.lbx
+++ b/tex/latex/biblatex-apa/lbx/swissgerman-apa.lbx
@@ -4,6 +4,7 @@
 % Following DGPs guidlines for German/Austrian/Swiss German
 % http://homepage.univie.ac.at/harald.werneck/Richtlinien_zur_Manuskriptgestaltung.pdf
 
+\NewBibliographyString{jourarticle}
 \NewBibliographyString{revisededition}
 \NewBibliographyString{typechair}
 \NewBibliographyString{typechairs}
@@ -68,6 +69,7 @@
 
 \DeclareBibliographyStrings{%
   inherit          = {swissgerman},
+  jourarticle      = {{Artikel}{Artikel}},
   tothe            = {{to\space the}{to\space the}},%FIXME
   ofthe            = {{of\space the}{of\space the}},%FIXME
   unitednations    = {{United\space Nations}{U\adddot N\adddot}},


### PR DESCRIPTION
The article number/eLocator is given in the `eid` field in the standard styles. `eprint` is for eprint servers etc.

Also fixes the comma issue reported in #107.