### PR TITLE
Simplify and debug external annotations

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -1370,21 +1370,19 @@
 \ExecuteBibliographyOptions{annotation=true}
 
 \renewbibmacro*{annotation}{%
-  \ifboolexpr{test {\iffieldundef{annotation}}
-              or not togl {bbx:annotation}}
-    {\IfFileExists{\bibannotationprefix\thefield{entrykey}.tex}
-       {\begingroup
-        \togglefalse{blx@bibliography}%
-        \newline
-        \setunit{}%
-        \printfile[annotation]{\bibannotationprefix\thefield{entrykey}.tex}%
-        \endgroup}
-      {}}
+  \ifboolexpr{
+    (
+     test {\iffieldundef{annotation}}
+     and not test {\IfFileExists{\bibannotationprefix\thefield{entrykey}.tex}}
+    )
+    or not togl {bbx:annotation}}
+    {}
     {\begingroup
      \togglefalse{blx@bibliography}%
      \newline
      \setunit{}%
-     \printfield{annotation}%
+     \iffieldundef{annotation}{\printfile[annotation]{\bibannotationprefix\thefield{entrykey}.tex}}%
+     {\printfield{annotation}}%
      \endgroup}}
 
 %


### PR DESCRIPTION
This was printing the bibliography when an external file existed and `annotate=false`.  I've fixed that and simplified the code to DRY.