### PR TITLE
Remove groupauthor field

### DIFF
--- a/bibtex/bib/biblatex-apa-test-references.bib
+++ b/bibtex/bib/biblatex-apa-test-references.bib
@@ -5,7 +5,7 @@
 }
 
 @BOOK{9.8:2,
-  GROUPAUTHOR = {{American Psychological Association} and {National Institutes of Health}},
+  AUTHOR = {{American Psychological Association} and {National Institutes of Health}},
   DATE   = {2014}
 }
 
@@ -1000,9 +1000,9 @@
 }
 
 % (APA 10.2 Example 32)
-% Note the use of GROUPAUTHOR instead of AUTHOR here
+% Note the use of AUTHOR instead of AUTHOR here
 @MANUAL{10.2:32a,
-  GROUPAUTHOR    = {{American Psychiatric Association}},
+  AUTHOR    = {{American Psychiatric Association}},
   TITLE          = {Diagnostic and Statistical Manual of Mental Disorders},
   SHORTHAND      = {DSM-5},
   EDITION        = {5},
@@ -1012,7 +1012,7 @@
 }
 
 @MANUAL{10.2:32b,
-  GROUPAUTHOR    = {{World Health Organization}},
+  AUTHOR    = {{World Health Organization}},
   TITLE          = {International Statistical Classification of Diseases and Related Health Problems},
   SHORTHAND      = {ICD-11},
   EDITION        = {11},
@@ -1023,14 +1023,14 @@
 
 % (APA 10.2 Example 33)
 @BOOK{10.2:33a,
-  GROUPAUTHOR    = {{American Psychological Association}},
+  AUTHOR    = {{American Psychological Association}},
   TITLE          = {{APA} Dictionary of Psychology},
   URL            = {https://dictionary.apa.org/},
   URLDATE        = {2019-06-14}
 }
 
 @BOOK{10.2:33b,
-  GROUPAUTHOR    = {{Merriam-Webster}},
+  AUTHOR    = {{Merriam-Webster}},
   TITLE          = {{Merriam-Webster.com} Dictionary},
   URL            = {https://www.merriam-webster.com/},
   URLDATE        = {2019-05-05}
@@ -1058,7 +1058,7 @@
 }
 
 % (APA 10.2 Example 35)
-% No AUTHOR or GROUPAUTHOR - title goes in author position
+% No AUTHOR or AUTHOR - title goes in author position
 @BOOK{10.2:35a,
   TITLE           = {{King} {James} {Bible}},
   DATE            = {2017},
@@ -1269,7 +1269,7 @@
 
 % (APA 10.3 Example 47)
 @INBOOK{10.3:47a,
-  GROUPAUTHOR    = {{American Psychological Association}},
+  AUTHOR    = {{American Psychological Association}},
   TITLE          = {Positive Transference},
   BOOKTITLE      = {{APA} Dictionary of Psychology},
   URL            = {https://dictionary.apa.org/positive-transference},
@@ -1277,7 +1277,7 @@
 }
 
 @INBOOK{10.3:47b,
-  GROUPAUTHOR    = {{Merriam-Webster}},
+  AUTHOR    = {{Merriam-Webster}},
   TITLE          = {Self-report},
   BOOKTITLE      = {{Merriam-Webster.com} Dictionary},
   URL            = {https://www.merriam-webster.com/dictionary/self-report},
@@ -1306,7 +1306,7 @@
 
 % (APA 10.4 Example 50)
 @REPORT{10.4:50a,
-  GROUPAUTHOR    = {{Australian Government Productivity Commission} and
+  AUTHOR    = {{Australian Government Productivity Commission} and
                     {New Zealand Productivity Commission}},
   TITLE          = {Strengthening Trans-{Tasman} Economic Relations},
   URL            = {https://www.pc.gov.au/inquiries/completed/australia-new-zealand/report/trans-tasman.pdf},
@@ -1314,7 +1314,7 @@
 }
 
 @REPORT{10.4:50b,
-  GROUPAUTHOR    = {{Canada Council for the Arts}},
+  AUTHOR    = {{Canada Council for the Arts}},
   TITLE          = {What We Heard},
   SUBTITLE       = {Summary of Key Findings: 2013 {Canada} {Council's}
                     {Inter-Arts} {Office} Consultation},
@@ -1325,7 +1325,7 @@
 % NUMBER field has the (localised) "No." prefix as the field is basically
 % numerical. This detection is automatic.
 @REPORT{10.4:50c,
-  GROUPAUTHOR    = {{National Cancer Institute}},
+  AUTHOR    = {{National Cancer Institute}},
   TITLE          = {Facing Forward},
   SUBTITLE       = {Life After Cancer Treatment},
   NUMBER         = {18-2424},
@@ -1365,7 +1365,7 @@
 
 % (APA 10.4 Example 53)
 @REPORT{10.4:53,
-  GROUPAUTHOR    = {{British Cardiovascular Society Working Group}},
+  AUTHOR    = {{British Cardiovascular Society Working Group}},
   TITLE          = {British {Cardiovascular} {Society} {Working} {Group} report},
   SUBTITLE       = {Out-of-hours Cardiovascular Care: {Management} of
                     Cardiac Emergencies and Hospital In-patients},
@@ -1376,7 +1376,7 @@
 
 % (APA 10.4 Example 54)
 @REPORT{10.4:54,
-  GROUPAUTHOR    = {{U.S. Securities and Exchange Commission}},
+  AUTHOR    = {{U.S. Securities and Exchange Commission}},
   TITLE          = {Agency Financial Report},
   SUBTITLE       = {Fiscal Year 2017},
   URL            = {https://www.sec.gov/files/sec-2017-agency-financial-report.pdf},
@@ -1385,21 +1385,21 @@
 
 % (APA 10.4 Example 55)
 @REPORT{10.4:55a,
-  GROUPAUTHOR    = {{American Counseling Association}},
+  AUTHOR    = {{American Counseling Association}},
   TITLE          = {2014 {ACA} code of ethics},
   URL            = {https://www.counseling.org/knowledge-center},
   DATE           = {2014}
 }
 
 @REPORT{10.4:55b,
-  GROUPAUTHOR    = {{American Nurses Association}},
+  AUTHOR    = {{American Nurses Association}},
   TITLE          = {Code of Ethics for Nurses with Interpretive Statements},
   URL            = {https://www.nursingworld.org/coe-view-only},
   DATE           = {2015}
 }
 
 @REPORT{10.4:55c,
-  GROUPAUTHOR    = {{American Psychological Association}},
+  AUTHOR    = {{American Psychological Association}},
   TITLE          = {Ethical Principles of Psychologists and Code of Conduct},
   TYPE           = {2002, amended effective June 1, 2010, and January 1, 2017},
   URL            = {https://www.apa.org/ethics/code/index.aspx},
@@ -1449,17 +1449,17 @@
 }
 
 % (APA 10.4 Example 59)
-% PUBLISHER should be ignored as it is the same as the GROUPAUTHOR
+% PUBLISHER should be ignored as it is the same as the AUTHOR
 % This is enforced by a Biber style source map
 @REPORT{10.4:59,
-  GROUPAUTHOR    = {{U.S. Food and Drug Administration}},
-  TITLE          = {{FDA} Authorizes First Interoperable Insulin Pup
-                    Intended to Allow Patients to Customize Treatment
-                    Through their Individual Diabetes Management Devices},
-  TITLEADDON     = {Press release},
-  PUBLISHER      = {{U.S. Food and Drug Administration}},
-  URL            = {https://www.fds.gov/NewsEvents/Newsroom/PressAnnouncements/ucm631412.htm},
-  DATE           = {2019-02-14}
+  AUTHOR     = {{U.S. Food and Drug Administration}},
+  TITLE      = {{FDA} Authorizes First Interoperable Insulin Pup
+                Intended to Allow Patients to Customize Treatment
+                Through their Individual Diabetes Management Devices},
+  TITLEADDON = {Press release},
+  PUBLISHER  = {{U.S. Food and Drug Administration}},
+  URL        = {https://www.fds.gov/NewsEvents/Newsroom/PressAnnouncements/ucm631412.htm},
+  DATE       = {2019-02-14}
 }
 
 % (APA 10.5 Example 60)
@@ -1744,7 +1744,7 @@
 
 @DATASET{10.9:75b,
   ENTRYSUBTYPE   = {Data set and code book},
-  GROUPAUTHOR    = {{National Center for Education Statistics}},
+  AUTHOR    = {{National Center for Education Statistics}},
   TITLE          = {Fast Response Survey System ({FRSS})},
   SUBTITLE       = {Teacher's Use of Educational Technology in {U.S.}
                     Public Schools, 2009},
@@ -1757,7 +1757,7 @@
 
 @DATASET{10.9:75c,
   ENTRYSUBTYPE = {Data set},
-  GROUPAUTHOR  = {{Pew Research Center}},
+  AUTHOR  = {{Pew Research Center}},
   TITLE        = {American Trends Panel {Wave} 26},
   URL          = {https://www.pewsocialtrends.org/dataset/american-trends-panel-wave-26/},
   DATE         = {2018}
@@ -1775,7 +1775,7 @@
 
 @DATASET{10.9:76b,
   ENTRYSUBTYPE = {Unpublished raw data},
-  GROUPAUTHOR  = {{Oregan Youth Authority}},
+  AUTHOR  = {{Oregan Youth Authority}},
   TITLE        = {Recidivism Outcomes},
   DATE         = {2011}
 }
@@ -1976,7 +1976,7 @@
 % ENTRYSUBTYPE is a localisation string
 @VIDEO{10.12:88b,
   ENTRYSUBTYPE    = {video},
-  GROUPAUTHOR     = {TED},
+  AUTHOR     = {TED},
   TITLE           = {Brené {Brown}},
   SUBTITLE        = {Listening to Shame},
   PUBLISHER       = {YouTube},
@@ -2022,7 +2022,7 @@
 % ENTRYSUBTYPE is a localisation string
 @VIDEO{10.12:90c,
   ENTRYSUBTYPE       = {video},
-  GROUPAUTHOR        = {{University of Oxford}},
+  AUTHOR        = {{University of Oxford}},
   TITLE              = {How Do Geckos Walk on Water?},
   PUBLISHER          = {YouTube},
   DATE               = {2016-12-06},
@@ -2077,7 +2077,7 @@
 % ENTRYSUBTYPE is a localisation string
 @AUDIO{10.13:92c,
   ENTRYSUBTYPE   = {song},
-  GROUPAUTHOR    = {{Childish Gambino}},
+  AUTHOR    = {{Childish Gambino}},
   TITLE          = {This is {America}},
   PUBLISHER      = {mcDJ and RCA},
   DATE           = {2018}
@@ -2265,8 +2265,8 @@
 % ENTRYTYPE is not a localisation string for such, unfortunately, universal neologisms
 @ONLINE{10.15:103a,
   ENTRYSUBTYPE            = {Tweet},
-  GROUPAUTHOR             = {{APA Education}},
-  GROUPAUTHOR+an:username = {1="@APAEducation"},
+  AUTHOR             = {{APA Education}},
+  AUTHOR+an:username = {1="@APAEducation"},
   TITLE                   = {College Students are Forming Mental-Health
                              Clubs--and They're Making a Difference @washingtonpost},
   TITLEADDON              = {Thumbnail with link attached},
@@ -2278,8 +2278,8 @@
 % ENTRYTYPE is not a localisation string for such, unfortunately, universal neologisms
 @ONLINE{10.15:103b,
   ENTRYSUBTYPE            = {Tweet},
-  GROUPAUTHOR             = {{Badlands National Park}},
-  GROUPAUTHOR+an:username = {1="@BadlandsNPS"},
+  AUTHOR             = {{Badlands National Park}},
+  AUTHOR+an:username = {1="@BadlandsNPS"},
   TITLE                   = {Biologists Have Identified More Than 400
                              Different Plant Species Growing in
                              {@BadlandsNPS} \#{DYK} \#biodoversity},
@@ -2304,8 +2304,8 @@
 % ENTRYTYPE is not a localisation string for such, unfortunately, universal neologisms
 @ONLINE{10.15:104,
   ENTRYSUBTYPE            = {Twitter profile},
-  GROUPAUTHOR             = {{APA Style}},
-  GROUPAUTHOR+an:username = {1="@APA\_Style"},
+  AUTHOR             = {{APA Style}},
+  AUTHOR+an:username = {1="@APA\_Style"},
   TITLE                   = {Tweets},
   EPRINT                  = {Twitter},
   URL                     = {https://twitter.com/APA_Style},
@@ -2330,7 +2330,7 @@
 % ENTRYTYPE is not a localisation string for such, unfortunately, universal neologisms
 @ONLINE{10.15:105b,
   ENTRYSUBTYPE            = {Infographic},
-  GROUPAUTHOR             = {{National Institute of Mental Health}},
+  AUTHOR             = {{National Institute of Mental Health}},
   TITLE                   = {Suicide Affects all Ages, Genders, Races, and
                              Ethnicities. {Check} out These 5 {Action}
                              {Steps} for {Helping} {Someone} in {Emotional}
@@ -2343,7 +2343,7 @@
 % Note protecting of automatic sentence-casing in SUBTITLE for url
 @ONLINE{10.15:105c,
   ENTRYSUBTYPE            = {video},
-  GROUPAUTHOR             = {{News From Science}},
+  AUTHOR             = {{News From Science}},
   TITLE                   = {These Frogs Walk Instead of Hop},
   SUBTITLE                = {{h}ttps://scimag.2{K}lriw{H}},
   EPRINT                  = {Facebook},
@@ -2355,7 +2355,7 @@
 % ENTRYTYPE is not a localisation string for such, unfortunately, universal neologisms
 @ONLINE{10.15:106,
   ENTRYSUBTYPE            = {Facebook page},
-  GROUPAUTHOR             = {{Smithsonian's National Zoo and Conservation
+  AUTHOR             = {{Smithsonian's National Zoo and Conservation
                              Biology Institute}},
   TITLE                   = {Home},
   EPRINT                  = {Facebook},
@@ -2367,8 +2367,8 @@
 % ENTRYSUBTYPE is a localisation string
 @ONLINE{10.15:107,
   ENTRYSUBTYPE            = {photographs},
-  GROUPAUTHOR             = {{Zeitz MOCAA}},
-  GROUPAUTHOR+an:username = {1="@zeitzmocaa"},
+  AUTHOR             = {{Zeitz MOCAA}},
+  AUTHOR+an:username = {1="@zeitzmocaa"},
   TITLE                   = {Grade 6 Learners from {Parkfields} {Primary}
                              {School} in {Hanover} {Park} Visited the
                              Museum for a Tour and Workshop Hosted by},
@@ -2381,8 +2381,8 @@
 % ENTRYTYPE is not a localisation string for such, unfortunately, universal neologisms
 @ONLINE{10.15:108,
   ENTRYSUBTYPE            = {Highlight},
-  GROUPAUTHOR             = {{The New York Public Library}},
-  GROUPAUTHOR+an:username = {1="@nypl"},
+  AUTHOR             = {{The New York Public Library}},
+  AUTHOR+an:username = {1="@nypl"},
   TITLE                   = {The Raven},
   EPRINT                  = {Instagram},
   URL                     = {https://bitly.com/2FV8bu3},
@@ -2393,8 +2393,8 @@
 % ENTRYTYPE is not a localisation string for such, unfortunately, universal neologisms
 @ONLINE{10.15:109,
   ENTRYSUBTYPE            = {Online forum post},
-  GROUPAUTHOR             = {{National Aeronautics Space Administration}},
-  GROUPAUTHOR+an:username = {1="nasa"},
+  AUTHOR             = {{National Aeronautics Space Administration}},
+  AUTHOR+an:username = {1="nasa"},
   TITLE                   = {I'm {NASA} Astronaut {Scott} {Tingle}. {Ask}
                              me anything about adjusting to being back on
                              {Earth} after my first spaceflight!},
@@ -2422,14 +2422,14 @@
 
 % (APA 10.16 Example 111)
 @ONLINE{10.16:111a,
-  GROUPAUTHOR        = {{Centers for Disease Control and Prevention}},
+  AUTHOR        = {{Centers for Disease Control and Prevention}},
   TITLE              = {People at High Risk of Developing Flu-related Complications},
   DATE               = {2018-01-23},
   URL                = {https://www.cdc.gov/flu/about/disease/high_risk.htm}
 }
 
 @ONLINE{10.16:111b,
-  GROUPAUTHOR        = {{World Health Organization}},
+  AUTHOR        = {{World Health Organization}},
   TITLE              = {Questions and Answers on Immunization and Vaccine Safety},
   DATE               = {2018-03},
   URL                = {https://www.who.int/features/qa/84/en/}
@@ -2455,14 +2455,14 @@
 }
 
 @ONLINE{10.16:113b,
-  GROUPAUTHOR   = {{National Nurses United}},
+  AUTHOR   = {{National Nurses United}},
   TITLE         = {What Employers Should do to Protect Nurses from {Zika}},
   URL           = {https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika}
 }
 
 % (APA 10.16 Example 114)
 @ONLINE{10.16:114,
-  GROUPAUTHOR   = {{U.S. Census Bureau}},
+  AUTHOR   = {{U.S. Census Bureau}},
   TITLE         = {{U.S.} and World Population Clock},
   ORGANIZATION  = {U.S. Department of Commerce},
   URL           = {https://www.census.gov/popclock/},

--- a/doc/biblatex-apa.tex
+++ b/doc/biblatex-apa.tex
@@ -312,15 +312,6 @@ states are language dependent and need localisation strings:
   \item[mansub] Manuscript submitted for publication
 \end{description}
 
-\subsubsection{Authors and Group Authors}
-APA 7th edition has a concept of a ``Group'' author \apa{9.11}. The style
-provides the |GROUPAUTHOR| entry field in all entry types. It is
-recommended to use |GROUPAUTHOR| when the author is an organisation or
-group as there are rules for name lists which are different for group
-authors (for example \apa{9.8}). |AUTHOR| is used much more extensively as
-the main agent of a work and the specific roles for particular agents is
-handled using |biber'|'s data annotation feature, see below.
-
 \subsubsection{Roles}
 The main role \apa{9.10} is of course specified by the |AUTHOR| entry
 field. You can attach specialised roles to any name in the |AUTHOR| field as
@@ -396,6 +387,10 @@ the examples.
 \section{Revision history}\label{rev}
 
 \begin{changelog}
+
+\begin{release}{9.15}{2021-??-??}
+\item Remove (need for) |GROUPAUTHOR| field
+\end{release}
 
 \begin{release}{9.14}{2020-08-28}
 \item Bugfixes, compat with biblatex 3.15

--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -251,7 +251,6 @@
   \sort{
     \field{sortname}
     \field{author}
-    \field{groupauthor}
     \field{editor}
     \field{sorttitle}
     \field{title}
@@ -282,11 +281,9 @@
   }
 }
 
-% Include groupauthor
 \DeclareLabelname{%
   \field{shortauthor}
   \field{author}
-  \field{groupauthor}
   \field{shorteditor}
   \field{editor}
 }
@@ -339,7 +336,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Enforce ignoring of PUBSTATE if there is a YEAR or DATE field
-% (APA 10.2:32) Remove PUBLISHER if it is the same as GROUPAUTHOR
+% (APA 10.2:32) Remove PUBLISHER if it is the same as AUTHOR
 % Force @COLLECTION, @REFERENCE->@BOOK and @INCOLLECTION,@INREFERENCE->@INBOOK
 
 \DeclareStyleSourcemap{
@@ -358,6 +355,9 @@
     }
     \map{
       \step[typesource=hardware, typetarget=software]
+    }
+    \map{
+      \step[fieldsource=groupauthor, fieldtarget=author]
     }
     \map{
       \pertype{proceedings}
@@ -382,7 +382,7 @@
       \step[fieldset=pubstate, null]
     }
     \map{
-      \step[fieldsource=groupauthor, match=\regexp{([^{}]+)}, final]
+      \step[fieldsource=author, match=\regexp{([^{}]+)}, final]
       \step[fieldsource=publisher, match=\regexp{$1}, final]%$
       \step[fieldset=publisher, null]
    }
@@ -582,7 +582,7 @@
     {}}
 
 \renewbibmacro*{author/editor}{%
-  \ifthenelse{\ifnameundef{author}\AND\ifnameundef{groupauthor}}
+  \ifnameundef{author}
     {\ifnameundef{editor}
       {\usebibmacro{title}%
         % need to clear all title fields so we don't get them again later
@@ -595,7 +595,7 @@
   \usebibmacro{labelyear+extradate}}
 
 \newbibmacro*{author/editor:related}{%
-  \ifthenelse{\ifnameundef{author}\AND\ifnameundef{groupauthor}}
+  \ifnameundef{author}
     {\ifnameundef{editor}
       {\usebibmacro{title}%
         % need to clear all title fields so we don't get them again later
@@ -624,9 +624,7 @@
      \clearname{editor}}}
 
 \renewbibmacro*{author}{%
-  \ifnameundef{author}
-    {\printnames[apaauthor][-\value{listtotal}]{groupauthor}}
-    {\printnames[apaauthor][-\value{listtotal}]{author}}%
+  \printnames[apaauthor][-\value{listtotal}]{author}%
   \setunit*{\addspace}%
   \printfield{nameaddon}%
   \ifnameundef{with}
@@ -639,9 +637,7 @@
      \setunit{\addspace}}}
 
 \newbibmacro*{author:related}{%
-  \ifnameundef{author}
-    {\printnames[apanames][-\value{listtotal}]{groupauthor}}
-    {\printnames[apanames][-\value{listtotal}]{author}}%
+  \printnames[apanames][-\value{listtotal}]{author}%
   \setunit*{\addspace}}
 
 %
@@ -660,13 +656,6 @@
        {\finalandcomma\addspace\&\space}
        {\addspace\&\space}}}
 
-\DeclareDelimFormat[bib,biblist]{finalnamedelim:apa:family-given}{%
-  \ifthenelse{\value{listcount}>\maxprtauth}
-    {}
-    {\ifthenelse{\ifcurrentname{groupauthor}\AND%
-                 \value{liststop}=2}
-     {\addspace\&\space}
-     {\finalandcomma\addspace\&\space}}}
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -934,26 +923,30 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Name format
 
+\newcommand*{\apablx@ifnotfinalname}{%
+  \ifboolexpr{
+    test {\ifnumless{\value{listcount}}{\value{liststop}}}
+    or
+    test \ifmorenames
+    }}
+
+\newcommand*{\apablx@ifrevnameappcomma}[2]{%
+  \ifdefvoid{#1}
+    {\ifdefvoid{#2}}
+    {\@secondoftwo}
+  {\@secondoftwo}
+  {\apablx@ifnotfinalname}%
+}
+
 % #1 = family name
 % #2 = given name
 % #3 = given name (initials)
 % #4 = name prefix
 % #5 = name suffix
 
-\newbibmacro*{name:delim:apa:family-given}[1]{%
-  \ifnumgreater{\value{listcount}}{\value{liststart}}
-    {\ifboolexpr{
-       test {\ifnumless{\value{listcount}}{\value{liststop}}}
-       or
-       test \ifmorenames
-     }
-       {\printdelim{multinamedelim}}
-       {\printdelim{finalnamedelim:apa:family-given}}}
-    {}}
-
 \newbibmacro*{name:apa:family-given}[5]{%
   \ifuseprefix
-    {\usebibmacro{name:delim:apa:family-given}{#4#1}%
+    {\usebibmacro{name:delim}{#4#1}%
      \usebibmacro{name:hook}{#4#1}%
      \ifdefvoid{#4}{}{%
        \mkbibnameprefix{#4}\isdot%
@@ -963,8 +956,11 @@
                       \ifthenelse{\value{uniquename}>1}
                         {\bibnamedelimd\mkbibbrackets{#2}}
                         {}}%
-     \ifdefvoid{#5}{}{\addcomma\bibnamedelimd\mkbibnamesuffix{#5}\isdot}}
-    {\usebibmacro{name:delim:apa:family-given}{#1}%
+     \ifdefvoid{#5}{}{\addcomma\bibnamedelimd\mkbibnamesuffix{#5}\isdot}%
+     \apablx@ifrevnameappcomma{#2}{#5}
+       {\addcomma}
+       {}}
+    {\usebibmacro{name:delim}{#1}%
      \usebibmacro{name:hook}{#1}%
      \mkbibnamefamily{#1}\isdot
      \ifboolexpe{%
@@ -980,7 +976,10 @@
      \ifdefvoid{#4}{}{%
        \bibnamedelimc\mkbibnameprefix{#4}%
        \ifprefchar{}{\bibnamedelimc}}%
-     \ifdefvoid{#5}{}{\addcomma\bibnamedelimd\mkbibnamesuffix{#5}\isdot}}}
+     \ifdefvoid{#5}{}{\addcomma\bibnamedelimd\mkbibnamesuffix{#5}\isdot}%
+     \apablx@ifrevnameappcomma{#2}{#5}
+       {\addcomma}
+       {}}}
 
 \newbibmacro*{name:apa:given-family}[5]{%
   \usebibmacro{name:delim}{#2#4#1#5}%
@@ -1142,7 +1141,7 @@
                  \ifnameundef{editora}\AND
                  \ifnameundef{editorb}\AND
                  \ifnameundef{editorc}\AND
-                 \(\ifnameundef{groupauthor}\AND\NOT\ifnameundef{author}\)}{}{\usebibmacro{in}}%
+                 \(\NOT\ifnameundef{author}\)}{}{\usebibmacro{in}}%
      \iffieldundef{maintitle}
       {}
       {\usebibmacro{maintitle}%

--- a/tex/latex/biblatex-apa/cbx/apa.cbx
+++ b/tex/latex/biblatex-apa/cbx/apa.cbx
@@ -137,9 +137,7 @@
        {\printnames{labelname}}%
        {\cbx@apa@ifnamesaved
           {\printnames{shortauthor}}
-          {\ifnameundef{groupauthor}
-            {\printnames[labelname]{author}}
-            {\printnames[labelname]{groupauthor}}%
+          {\printnames[labelname]{author}%
            \addspace\printnames[sabrackets]{shortauthor}}}%
         \savefield{fullhash}{\cbx@lasthash}}}%
    \setunit{\multicitedelim}}
@@ -170,9 +168,7 @@
        {\printnames{labelname}}%
        {\cbx@apa@ifnamesaved
          {\printnames{shortauthor}}
-         {\ifnameundef{groupauthor}
-           {\printnames[labelname]{author}}
-           {\printnames[labelname]{groupauthor}}%
+         {\printnames[labelname]{author}%
           \addspace\printnames[sabrackets]{shortauthor}}}%
        \setunit{\printdelim{nameyeardelim}}%
       \usebibmacro{cite:plabelyear+extradate}%
@@ -209,9 +205,7 @@
     % Cite using short author
          {\cbx@apa@ifnamesaved
            {\printnames{shortauthor}}
-           {\ifnameundef{groupauthor}
-             {\printnames[labelname]{author}}
-             {\printnames[labelname]{groupauthor}}}}%
+           {\printnames[labelname]{author}}}%
   % Year
         \setunit{\global\booltrue{cbx:parens}\addspace\bibopenparen}%
   % Put the shortauthor inside the year brackets if necessary

--- a/tex/latex/biblatex-apa/dbx/apa.dbx
+++ b/tex/latex/biblatex-apa/dbx/apa.dbx
@@ -23,7 +23,6 @@
   nameonly}
 
 \DeclareDatamodelFields[type=list, datatype=name]{
-  groupauthor,
   narrator,
   execproducer,
   execdirector,
@@ -41,7 +40,6 @@
 
 \DeclareDatamodelEntryfields{
   with,
-  groupauthor,
   narrator,
   execproducer,
   execdirector}
@@ -147,10 +145,7 @@
 
 \DeclareDatamodelConstraints[book,inbook,article,report]{
   \constraint[type=mandatory]{
-    \constraintfieldsor{
-      \constraintfield{author}
-      \constraintfield{groupauthor}
-    }
+    \constraintfield{author}
     \constraintfield{title}
   }
 }


### PR DESCRIPTION
See #143.

The field `groupauthor` was only used to get the commas between names right. For all other intents and purposes it behaved exactly like `author`.

Since `groupauthor` is not a standard `biblatex` field and it feels unnatural to distinguish group authors and authors (plus, how would you treat "mixed" author lists of group authors and people?) I thought it would be useful to consolidate things back to `author`.

---

I couldn't properly do a diff over `biblatex-apa-test` because there were differences in the font metric that made comparison on that large a scale impossible.