### PR TITLE
Use unstarred \DeclareDelimAlias (#125)

### DIFF
--- a/tex/latex/biblatex-apa/bbx/apa.bbx
+++ b/tex/latex/biblatex-apa/bbx/apa.bbx
@@ -575,7 +575,7 @@
     {}}
 
 \DeclareDelimFormat[bib,biblist]{nameyeardelim}{\newunitpunct}
-\DeclareDelimAlias*[bib,biblist]{nonameyeardelim}{nameyeardelim}
+\DeclareDelimAlias[bib,biblist]{nonameyeardelim}{nameyeardelim}
 
 \renewbibmacro*{author/editor}{%
   \ifnameundef{author}


### PR DESCRIPTION
This removes the starred version also in https://github.com/plk/biblatex-apa/commit/8e70f178758d40a9402478ab2aaeb2e1ab071fe3. See #125.