### PR TITLE
Switch groupauthor to author (#144, #156)

### DIFF
--- a/bibtex/bib/biblatex-apa-test-citations.bib
+++ b/bibtex/bib/biblatex-apa-test-citations.bib
@@ -60,24 +60,24 @@
 }
 
 @BOOK{8.12d,
-  GROUPAUTHOR    = {{Department of Veteran Affairs}},
+  author         = {{Department of Veteran Affairs}},
   TITLE          = {Title1}
 }
 
 @BOOK{8.12e,
-  GROUPAUTHOR    = {{Department of Veteran Affairs}},
+  author         = {{Department of Veteran Affairs}},
   TITLE          = {Title1},
   DATE           = {2017}
 }
 
 @BOOK{8.12f,
-  GROUPAUTHOR    = {{Department of Veteran Affairs}},
+  author         = {{Department of Veteran Affairs}},
   TITLE          = {Title2},
   DATE           = {2017}
 }
 
 @BOOK{8.12g,
-  GROUPAUTHOR    = {{Department of Veteran Affairs}},
+  author         = {{Department of Veteran Affairs}},
   TITLE          = {Title1},
   DATE           = {2019}
 }
@@ -169,7 +169,7 @@
 
 % (APA 8.13)
 @BOOK{8.13a,
-  GROUPAUTHOR    = {{Centers for Disease Control and Prevention}},
+  author         = {{Centers for Disease Control and Prevention}},
   TITLE          = {Title},
   DATE           = {2019}
 }
@@ -205,7 +205,7 @@
 }
 
 @BOOK{8.13g,
-  GROUPAUTHOR    = {{Beck Institute for Cognitive Behaviour Therapy}},
+  author         = {{Beck Institute for Cognitive Behaviour Therapy}},
   TITLE          = {Title},
   DATE           = {2012}
 }
@@ -284,14 +284,14 @@
 }
 
 @BOOK{8.17d,
-  GROUPAUTHOR    = {{National Institute of Mental Health}},
+  author         = {{National Institute of Mental Health}},
   SHORTAUTHOR    = {NIMH},
   TITLE          = {Title},
   DATE           = {2020}
 }
 
 @BOOK{8.17e,
-  GROUPAUTHOR    = {{Stanford University}},
+  author         = {{Stanford University}},
   TITLE          = {Title},
   DATE           = {2020}
 }
@@ -309,7 +309,7 @@
 }
 
 @BOOK{8.17h,
-  GROUPAUTHOR    = {{American Educational Research Association} and {Some other group} and {Yet another group}},
+  author         = {{American Educational Research Association} and {Some other group} and {Yet another group}},
   TITLE          = {Title},
   DATE           = {2014}
 }
@@ -432,14 +432,14 @@
 
 % (APA 8.21)
 @BOOK{8.21a,
-  GROUPAUTHOR    = {{The American Psychological Association}},
+  author         = {{The American Psychological Association}},
   SHORTAUTHOR    = {APA},
   TITLE          = {Title1},
   DATE           = {2017}
 }
 
 @BOOK{8.21b,
-  GROUPAUTHOR    = {{The American Psychological Association}},
+  author         = {{The American Psychological Association}},
   SHORTAUTHOR    = {APA},
   TITLE          = {Title2},
   DATE           = {2006}


### PR DESCRIPTION
This removes references to the now-obsolete `groupauthor` field (#144) in `biblatex-apa-test-citations.bib`.